### PR TITLE
Reorder asset chain params for better readability

### DIFF
--- a/src/assetchains
+++ b/src/assetchains
@@ -21,7 +21,7 @@ function komodo_asset ()
         supply=" "
     fi
 
-    $komodo_binary -pubkey=$pubkey -ac_name=$1 $supply -addnode=$seed_ip $gen $args &
+    $komodo_binary -ac_name=$1 $gen $supply $args -pubkey=$pubkey -addnode=$seed_ip &
     sleep $delay
 }
 


### PR DESCRIPTION
If you have a load of assets running and you want to quickly view which are being mined or which are eating up CPU with `htop` or `ps` it's currently pretty awakward because the pubkey pushes the params out of view.

This PR puts `-ac_name` and `-gen` first so you can quickly see from terminal output which asset chains are which and which one's are being mined.