### PR TITLE
fix hang / deadlock with wallet filter enabled and other patches

### DIFF
--- a/.github/workflows/komodod_ci.yml
+++ b/.github/workflows/komodod_ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install deps (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get remove php7.1-fpm php7.2-fpm php7.3-fpm php7.3-common
+          sudo apt-get remove php7.1-fpm php7.2-fpm php7.3-fpm php7.3-common php7.4-fpm
           sudo apt-get update
           sudo apt-get upgrade -y
           sudo apt-get update

--- a/.github/workflows/komodod_ci.yml
+++ b/.github/workflows/komodod_ci.yml
@@ -259,7 +259,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get remove php5.6-fpm php7.0-fpm php7.1-fpm php7.2-fpm php7.3-fpm php7.3-common
+        sudo apt-get remove php5.6-fpm php7.0-fpm php7.1-fpm php7.2-fpm php7.3-fpm php7.3-common php7.4-fpm
         sudo apt-get update
         sudo apt-get upgrade -y
         sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool libncurses-dev unzip git python zlib1g-dev wget bsdmainutils automake libboost-all-dev libssl-dev libprotobuf-dev protobuf-compiler libqrencode-dev libdb++-dev ntp ntpdate nano software-properties-common curl libevent-dev libcurl4-gnutls-dev cmake clang libsodium-dev -y

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -69,7 +69,8 @@ CBlockIndex *komodo_chainactive(int32_t height);
 
 void WaitForShutdown(boost::thread_group* threadGroup)
 {
-    int32_t i,height; CBlockIndex *pindex; bool fShutdown = ShutdownRequested(); const uint256 zeroid;
+    int32_t i,height; CBlockIndex *pindex; const uint256 zeroid;
+    bool fShutdown = ShutdownRequested();
     // Tell the main threads to shutdown.
     if (komodo_currentheight()>KOMODO_EARLYTXID_HEIGHT && KOMODO_EARLYTXID!=zeroid && ((height=tx_height(KOMODO_EARLYTXID))==0 || height>KOMODO_EARLYTXID_HEIGHT))
     {
@@ -86,35 +87,14 @@ void WaitForShutdown(boost::thread_group* threadGroup)
     } //else fprintf(stderr,"cant find height 1\n");*/
     if ( ASSETCHAINS_CBOPRET != 0 )
         komodo_pricesinit();
+    /*
+        komodo_passport_iteration and komodo_cbopretupdate moved to a separate thread
+        ThreadUpdateKomodoInternals fired every second (see init.cpp), original wait
+        for shutdown loop restored.
+    */
     while (!fShutdown)
     {
-        //fprintf(stderr,"call passport iteration\n");
-        if ( ASSETCHAINS_SYMBOL[0] == 0 )
-        {
-            if ( KOMODO_NSPV_FULLNODE )
-                komodo_passport_iteration();
-            for (i=0; i<10; i++)
-            {
-                fShutdown = ShutdownRequested();
-                if ( fShutdown != 0 )
-                    break;
-                MilliSleep(1000);
-            }
-        }
-        else
-        {
-            //komodo_interestsum();
-            //komodo_longestchain();
-            if ( ASSETCHAINS_CBOPRET != 0 )
-                komodo_cbopretupdate(0);
-            for (i=0; i<=ASSETCHAINS_BLOCKTIME/5; i++)
-            {
-                fShutdown = ShutdownRequested();
-                if ( fShutdown != 0 )
-                    break;
-                MilliSleep(1000);
-            }
-        }
+        MilliSleep(200);
         fShutdown = ShutdownRequested();
     }
     if (threadGroup)

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -74,7 +74,7 @@ namespace Checkpoints {
             fWorkAfter = nExpensiveAfter*fSigcheckVerificationFactor;
         }
 
-        return fWorkBefore / (fWorkBefore + fWorkAfter);
+        return std::min(fWorkBefore / (fWorkBefore + fWorkAfter), 1.0);
     }
 
     int GetTotalBlocksEstimate(const CChainParams::CCheckpointData& data)

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -25,6 +25,7 @@
 #include <event2/http.h>
 #include <event2/thread.h>
 #include <event2/buffer.h>
+#include <event2/bufferevent.h>
 #include <event2/util.h>
 #include <event2/keyvalq_struct.h>
 
@@ -250,6 +251,16 @@ static std::string RequestMethodString(HTTPRequest::RequestMethod m)
 /** HTTP request callback */
 static void http_request_cb(struct evhttp_request* req, void* arg)
 {
+    // Disable reading to work around a libevent bug, fixed in 2.2.0.
+    if (event_get_version_number() >= 0x02010600 && event_get_version_number() < 0x02020001) {
+        evhttp_connection* conn = evhttp_request_get_connection(req);
+        if (conn) {
+            bufferevent* bev = evhttp_connection_get_bufferevent(conn);
+            if (bev) {
+                bufferevent_disable(bev, EV_READ);
+            }
+        }
+    }
     std::unique_ptr<HTTPRequest> hreq(new HTTPRequest(req));
 
     // Early address-based allow check
@@ -604,8 +615,21 @@ void HTTPRequest::WriteReply(int nStatus, const std::string& strReply)
     struct evbuffer* evb = evhttp_request_get_output_buffer(req);
     assert(evb);
     evbuffer_add(evb, strReply.data(), strReply.size());
-    HTTPEvent* ev = new HTTPEvent(eventBase, true,
-        boost::bind(evhttp_send_reply, req, nStatus, (const char*)NULL, (struct evbuffer *)NULL));
+    auto req_copy = req;
+    HTTPEvent* ev = new HTTPEvent(eventBase, true, [req_copy, nStatus]{
+        evhttp_send_reply(req_copy, nStatus, (const char*)NULL, (struct evbuffer *)NULL);
+        // Re-enable reading from the socket. This is the second part of the libevent
+        // workaround above.
+        if (event_get_version_number() >= 0x02010600 && event_get_version_number() < 0x02020001) {
+            evhttp_connection* conn = evhttp_request_get_connection(req_copy);
+            if (conn) {
+                bufferevent* bev = evhttp_connection_get_bufferevent(conn);
+                if (bev) {
+                    bufferevent_enable(bev, EV_READ | EV_WRITE);
+                }
+            }
+        }
+    });
     ev->trigger(0);
     replySent = true;
     req = 0; // transferred back to main thread
@@ -670,4 +694,3 @@ void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch)
         pathHandlers.erase(i);
     }
 }
-

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -792,7 +792,7 @@ void ThreadUpdateKomodoInternals() {
                         komodo_passport_iteration(); // call komodo_interestsum() inside (possible locks)
                         auto finish = std::chrono::high_resolution_clock::now();
                         std::chrono::duration<double, std::milli> elapsed = finish - start;
-                        std::cerr << DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) << " " << __FUNCTION__ << ": komodo_passport_iteration -> Elapsed Time: " << elapsed.count() << " seconds" << std::endl;
+                        std::cerr << DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) << " " << __FUNCTION__ << ": komodo_passport_iteration -> Elapsed Time: " << elapsed.count() << " ms" << std::endl;
                     }
                 }
             else

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -782,9 +782,6 @@ void ThreadUpdateKomodoInternals() {
 
             boost::this_thread::interruption_point();
 
-            AssertLockHeld(cs_main);
-            AssertLockHeld(pwalletMain->cs_wallet);
-
             if ( ASSETCHAINS_SYMBOL[0] == 0 )
                 {
                     if ( KOMODO_NSPV_FULLNODE ) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -749,6 +749,65 @@ void ThreadNotifyRecentlyAdded()
     }
 }
 
+/* declarations needed for ThreadUpdateKomodoInternals */
+void komodo_passport_iteration();
+void komodo_cbopretupdate(int32_t forceflag);
+
+void ThreadUpdateKomodoInternals() {
+    RenameThread("int-updater");
+
+    boost::signals2::connection c = uiInterface.NotifyBlockTip.connect(
+        [](const uint256& hashNewTip) mutable {
+            CBlockIndex* pblockindex = mapBlockIndex[hashNewTip];
+            std::cerr << __FUNCTION__ << ": NotifyBlockTip " << hashNewTip.ToString() << " - " << pblockindex->GetHeight() << std::endl;
+        }
+        );
+
+    try {
+        while (true) {
+            // Run the updater on an integer second in the steady clock.
+            auto now = std::chrono::steady_clock::now().time_since_epoch();
+            auto nextFire = std::chrono::duration_cast<std::chrono::seconds>(
+                now + std::chrono::seconds(1));
+            std::this_thread::sleep_until(
+                std::chrono::time_point<std::chrono::steady_clock>(nextFire));
+
+            boost::this_thread::interruption_point();
+
+            AssertLockHeld(cs_main);
+            AssertLockHeld(pwalletMain->cs_wallet);
+
+            if ( ASSETCHAINS_SYMBOL[0] == 0 )
+                {
+                    if ( KOMODO_NSPV_FULLNODE ) {
+                        auto start = std::chrono::high_resolution_clock::now();
+                        komodo_passport_iteration(); // call komodo_interestsum() inside (possible locks)
+                        auto finish = std::chrono::high_resolution_clock::now();
+                        std::chrono::duration<double, std::milli> elapsed = finish - start;
+                        std::cerr << __FUNCTION__ << ": komodo_passport_iteration -> Elapsed Time: " << elapsed.count() << " seconds" << std::endl;
+                    }
+                }
+            else
+                {
+                    if ( ASSETCHAINS_CBOPRET != 0 )
+                        komodo_cbopretupdate(0);
+                }
+        }
+    }
+    catch (const boost::thread_interrupted&) {
+        std::cerr << "ThreadUpdateKomodoInternals() interrupted" << std::endl;
+        c.disconnect();
+        throw;
+    }
+    catch (const std::exception& e) {
+        PrintExceptionContinue(&e, "ThreadUpdateKomodoInternals()");
+    }
+    catch (...) {
+        PrintExceptionContinue(NULL, "ThreadUpdateKomodoInternals()");
+    }
+
+}
+
 /** Sanity checks
  *  Ensure that Bitcoin is running in a usable environment with all
  *  necessary library support.
@@ -1991,6 +2050,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // Start the thread that notifies listeners of transactions that have been
     // recently added to the mempool.
     threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "txnotify", &ThreadNotifyRecentlyAdded));
+
+    // Start the thread that updates komodo internal structures
+    threadGroup.create_thread(&ThreadUpdateKomodoInternals);
 
     if (GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))
         StartTorControl(threadGroup, scheduler);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -771,7 +771,7 @@ void ThreadUpdateKomodoInternals() {
             if ( ASSETCHAINS_SYMBOL[0] == 0 )
                 fireDelaySeconds = 10;
             else
-                fireDelaySeconds = ASSETCHAINS_BLOCKTIME/5;
+                fireDelaySeconds = ASSETCHAINS_BLOCKTIME/5 + 1;
 
             // Run the updater on an integer fireDelaySeconds seconds in the steady clock.
             auto now = std::chrono::steady_clock::now().time_since_epoch();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -763,12 +763,20 @@ void ThreadUpdateKomodoInternals() {
         }
         );
 
+    int fireDelaySeconds = 10;
+
     try {
         while (true) {
-            // Run the updater on an integer second in the steady clock.
+
+            if ( ASSETCHAINS_SYMBOL[0] == 0 )
+                fireDelaySeconds = 10;
+            else
+                fireDelaySeconds = ASSETCHAINS_BLOCKTIME/5;
+
+            // Run the updater on an integer fireDelaySeconds seconds in the steady clock.
             auto now = std::chrono::steady_clock::now().time_since_epoch();
             auto nextFire = std::chrono::duration_cast<std::chrono::seconds>(
-                now + std::chrono::seconds(1));
+                now + std::chrono::seconds(fireDelaySeconds));
             std::this_thread::sleep_until(
                 std::chrono::time_point<std::chrono::steady_clock>(nextFire));
 
@@ -784,7 +792,7 @@ void ThreadUpdateKomodoInternals() {
                         komodo_passport_iteration(); // call komodo_interestsum() inside (possible locks)
                         auto finish = std::chrono::high_resolution_clock::now();
                         std::chrono::duration<double, std::milli> elapsed = finish - start;
-                        std::cerr << __FUNCTION__ << ": komodo_passport_iteration -> Elapsed Time: " << elapsed.count() << " seconds" << std::endl;
+                        std::cerr << DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) << " " << __FUNCTION__ << ": komodo_passport_iteration -> Elapsed Time: " << elapsed.count() << " seconds" << std::endl;
                     }
                 }
             else

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1592,32 +1592,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     fReindex = GetBoolArg("-reindex", false);
 
-    // Upgrading to 0.8; hard-link the old blknnnn.dat files into /blocks/
-    boost::filesystem::path blocksDir = GetDataDir() / "blocks";
-    if (!boost::filesystem::exists(blocksDir))
-    {
-        boost::filesystem::create_directories(blocksDir);
-        bool linked = false;
-        for (unsigned int i = 1; i < 10000; i++) {
-            boost::filesystem::path source = GetDataDir() / strprintf("blk%04u.dat", i);
-            if (!boost::filesystem::exists(source)) break;
-            boost::filesystem::path dest = blocksDir / strprintf("blk%05u.dat", i-1);
-            try {
-                boost::filesystem::create_hard_link(source, dest);
-                LogPrintf("Hardlinked %s -> %s\n", source.string(), dest.string());
-                linked = true;
-            } catch (const boost::filesystem::filesystem_error& e) {
-                // Note: hardlink creation failing is not a disaster, it just means
-                // blocks will get re-downloaded from peers.
-                LogPrintf("Error hardlinking blk%04u.dat: %s\n", i, e.what());
-                break;
-            }
-        }
-        if (linked)
-        {
-            fReindex = true;
-        }
-    }
+    boost::filesystem::create_directories(GetDataDir() / "blocks");
 
     // block tree db settings
     int dbMaxOpenFiles = GetArg("-dbmaxopenfiles", DEFAULT_DB_MAX_OPEN_FILES);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -756,12 +756,12 @@ void komodo_cbopretupdate(int32_t forceflag);
 void ThreadUpdateKomodoInternals() {
     RenameThread("int-updater");
 
-    boost::signals2::connection c = uiInterface.NotifyBlockTip.connect(
-        [](const uint256& hashNewTip) mutable {
-            CBlockIndex* pblockindex = mapBlockIndex[hashNewTip];
-            std::cerr << __FUNCTION__ << ": NotifyBlockTip " << hashNewTip.ToString() << " - " << pblockindex->GetHeight() << std::endl;
-        }
-        );
+    // boost::signals2::connection c = uiInterface.NotifyBlockTip.connect(
+    //     [](const uint256& hashNewTip) mutable {
+    //         CBlockIndex* pblockindex = mapBlockIndex[hashNewTip];
+    //         std::cerr << __FUNCTION__ << ": NotifyBlockTip " << hashNewTip.ToString() << " - " << pblockindex->GetHeight() << std::endl;
+    //     }
+    //     );
 
     int fireDelaySeconds = 10;
 
@@ -789,7 +789,7 @@ void ThreadUpdateKomodoInternals() {
                         komodo_passport_iteration(); // call komodo_interestsum() inside (possible locks)
                         auto finish = std::chrono::high_resolution_clock::now();
                         std::chrono::duration<double, std::milli> elapsed = finish - start;
-                        std::cerr << DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) << " " << __FUNCTION__ << ": komodo_passport_iteration -> Elapsed Time: " << elapsed.count() << " ms" << std::endl;
+                        // std::cerr << DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) << " " << __FUNCTION__ << ": komodo_passport_iteration -> Elapsed Time: " << elapsed.count() << " ms" << std::endl;
                     }
                 }
             else
@@ -800,8 +800,8 @@ void ThreadUpdateKomodoInternals() {
         }
     }
     catch (const boost::thread_interrupted&) {
-        std::cerr << "ThreadUpdateKomodoInternals() interrupted" << std::endl;
-        c.disconnect();
+        // std::cerr << "ThreadUpdateKomodoInternals() interrupted" << std::endl;
+        // c.disconnect();
         throw;
     }
     catch (const std::exception& e) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1922,7 +1922,7 @@ void static BitcoinMiner()
                 //fprintf(stderr,"gotinvalid.%d\n",gotinvalid);
                 if ( gotinvalid != 0 )
                     break;
-                komodo_longestchain();
+                // komodo_longestchain();
                 // Hash state
                 KOMODO_CHOSEN_ONE = 0;
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -189,6 +189,14 @@ int32_t komodo_longestchain()
         depth = 0;
     if ( depth == 0 )
     {
+
+        TRY_LOCK(cs_main, lockMain); // Acquire cs_main
+        if (!lockMain) {
+            std::cerr << __FUNCTION__ << ": can't acquire cs_main!" << std::endl;
+            return(KOMODO_LONGESTCHAIN);
+        }
+        std::cerr << __FUNCTION__ << ": acquire cs_main success!" << std::endl;
+
         depth++;
         vector<CNodeStats> vstats;
         {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -190,12 +190,18 @@ int32_t komodo_longestchain()
     if ( depth == 0 )
     {
 
+        /**
+         * Seems here we need to try to lock cs_main, to avoid wrong order of lock (cs_main, cs_vNodes),
+         * implementation of getting max(nStartingHeight, nSyncHeight, nCommonHeight) from CNodeStateStats
+         * and loop here is similar to getpeerinfo RPC and there we have LOCK(cs_main). If we'll not able
+         * to acquire lock on cs_main komodo_longestchain() will return previous saved value of
+         * KOMODO_LONGESTCHAIN, anyway, on next call it will be updated, when lock will success.
+        */
+
         TRY_LOCK(cs_main, lockMain); // Acquire cs_main
         if (!lockMain) {
-            std::cerr << __FUNCTION__ << ": can't acquire cs_main!" << std::endl;
             return(KOMODO_LONGESTCHAIN);
         }
-        std::cerr << __FUNCTION__ << ": acquire cs_main success!" << std::endl;
 
         depth++;
         vector<CNodeStats> vstats;

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -65,10 +65,8 @@ bool TransactionSignatureCreator::CreateSig(std::vector<unsigned char>& vchSig, 
     else if (pprivKey)
         key = *pprivKey;
     else if (!keystore || !keystore->GetKey(address, key))
-    {
-        fprintf(stderr,"keystore.%p error\n",keystore);
         return false;
-    }
+
     //fprintf(stderr,"privkey (%s) for %s\n",NSPV_wifstr,EncodeDestination(key.GetPubKey().GetID()).c_str());
 
     if (scriptCode.IsPayToCryptoCondition())

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -116,10 +116,7 @@ static bool Sign1(const CKeyID& address, const BaseSignatureCreator& creator, co
 {
     vector<unsigned char> vchSig;
     if (!creator.CreateSig(vchSig, address, scriptCode, consensusBranchId))
-    {
-        fprintf(stderr,"Sign1 creatsig error\n");
         return false;
-    }
     ret.push_back(vchSig);
     return true;
 }

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -20,7 +20,8 @@ static const string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO
 static const string SAFE_CHARS[] =
 {
     CHARS_ALPHA_NUM + " .,;_/:?@()", // SAFE_CHARS_DEFAULT
-    CHARS_ALPHA_NUM + " .,;_?@" // SAFE_CHARS_UA_COMMENT
+    CHARS_ALPHA_NUM + " .,;_?@", // SAFE_CHARS_UA_COMMENT
+    CHARS_ALPHA_NUM + "!*'();:@&=+$,/?#[]-_.~%" // SAFE_CHARS_URI
 };
 
 string SanitizeString(const string& str, int rule)

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -26,7 +26,8 @@
 enum SafeChars
 {
     SAFE_CHARS_DEFAULT, //!< The full set of allowed chars
-    SAFE_CHARS_UA_COMMENT //!< BIP-0014 subset
+    SAFE_CHARS_UA_COMMENT, //!< BIP-0014 subset
+    SAFE_CHARS_URI //!< Chars allowed in URIs (RFC 3986)
 };
 
 std::string SanitizeFilename(const std::string& str);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1752,7 +1752,6 @@ bool CWallet::UpdatedNoteData(const CWalletTx& wtxIn, CWalletTx& wtx)
  * pblock is optional, but should be provided if the transaction is known to be in a block.
  * If fUpdate is true, existing transactions will be updated.
  */
-
 bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate)
 {
     {
@@ -1775,10 +1774,11 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
             /**
              * New implementation of wallet filter code.
              *
-             * If any vout of tx is belongs to wallet (IsMine(tx) == true) and tx is not from us, mean,
-             * if every vin not belongs to our wallet (IsFromMe(tx) == false), then tx need to be checked
-             * through wallet filter. If tx haven't any vin from trusted / whitelisted address it shouldn't
-             * be added into wallet.
+             * If any vout of tx is belongs to wallet (IsMine(tx) == true) and tx
+             * is not from us, mean, if every vin not belongs to our wallet
+             * (IsFromMe(tx) == false), then tx need to be checked through wallet
+             * filter. If tx haven't any vin from trusted / whitelisted address it
+             * shouldn't be added into wallet.
             */
 
             if (!mapMultiArgs["-whitelistaddress"].empty())
@@ -1797,7 +1797,8 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
                                 if (EncodeDestination(dest) == strWhiteListAddress)
                                 {
                                     fIsFromWhiteList = true;
-                                    std::cerr << __FUNCTION__ << " tx." << tx.GetHash().ToString() << " passed wallet filter! whitelistaddress." << EncodeDestination(dest) << std::endl;
+                                    // std::cerr << __FUNCTION__ << " tx." << tx.GetHash().ToString() << " passed wallet filter! whitelistaddress." << EncodeDestination(dest) << std::endl;
+                                    LogPrintf("tx.%s passed wallet filter! whitelistaddress.%s\n", tx.GetHash().ToString(),EncodeDestination(dest));
                                     break;
                                 }
                             }
@@ -1805,7 +1806,8 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
                     }
                     if (!fIsFromWhiteList)
                     {
-                        std::cerr << __FUNCTION__ << " tx." << tx.GetHash().ToString() << " is NOT passed wallet filter!" << std::endl;
+                        // std::cerr << __FUNCTION__ << " tx." << tx.GetHash().ToString() << " is NOT passed wallet filter!" << std::endl;
+                        LogPrintf("tx.%s is NOT passed wallet filter!\n", tx.GetHash().ToString());
                         return false;
                     }
                 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1770,51 +1770,8 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
                 return false;
             }
         }
-        static std::string NotaryAddress; static bool didinit;
-        if ( !didinit && NotaryAddress.empty() && NOTARY_PUBKEY33[0] != 0 )
-        {
-            didinit = true;
-            char Raddress[64]; 
-            pubkey2addr((char *)Raddress,(uint8_t *)NOTARY_PUBKEY33);
-            NotaryAddress.assign(Raddress);
-            vWhiteListAddress = mapMultiArgs["-whitelistaddress"];
-            if ( !vWhiteListAddress.empty() )
-            {
-                fprintf(stderr, "Activated Wallet Filter \n  Notary Address: %s \n  Adding whitelist address's:\n", NotaryAddress.c_str());
-                for ( auto wladdr : vWhiteListAddress )
-                    fprintf(stderr, "    %s\n", wladdr.c_str());
-            }
-        }
         if (fExisted || IsMine(tx) || IsFromMe(tx) || sproutNoteData.size() > 0 || saplingNoteData.size() > 0)
         {
-            // wallet filter for notary nodes. Enables by setting -whitelistaddress= as startup param or in conf file (works same as -addnode byut with R-address's)
-            if ( !tx.IsCoinBase() && !vWhiteListAddress.empty() && !NotaryAddress.empty() ) 
-            {
-                int numvinIsOurs = 0, numvinIsWhiteList = 0;  
-                for (size_t i = 0; i < tx.vin.size(); i++)
-                {
-                    uint256 hash; CTransaction txin; CTxDestination address;
-                    if ( myGetTransaction(tx.vin[i].prevout.hash,txin,hash) && ExtractDestination(txin.vout[tx.vin[i].prevout.n].scriptPubKey, address) )
-                    {
-                        if ( CBitcoinAddress(address).ToString() == NotaryAddress )
-                            numvinIsOurs++;
-                        for ( auto wladdr : vWhiteListAddress )
-                        {
-                            if ( CBitcoinAddress(address).ToString() == wladdr )
-                            {
-                                //fprintf(stderr, "We received from whitelisted address.%s\n", wladdr.c_str());
-                                numvinIsWhiteList++;
-                            }
-                        }
-                    }
-                }
-                // Now we know if it was a tx sent to us, by either a whitelisted address, or ourself.
-                if ( numvinIsOurs != 0 )
-                    fprintf(stderr, "We sent from address: %s vins: %d\n",NotaryAddress.c_str(),numvinIsOurs);
-                if ( numvinIsOurs == 0 && numvinIsWhiteList == 0 )
-                    return false;
-            }
-
             CWalletTx wtx(this,tx);
 
             if (sproutNoteData.size() > 0) {


### PR DESCRIPTION
This PR should fix daemon hang / deadlock with wallet filter enabled, also it have some fixes / patches from various upstreams (BTC, ZEC):

- code refactoring: move komodo internal structures update from wait to shutdown loop into separate thread, which seemed more logic. wait for shutdown loop almost restored to it's original state from ZEC.
- miner: remove komodo_longestchain call from miner internal loop, we defenitely don't want to iterate all connected nodes stats on each miner nOnce iteration.
- wallet filter: fully remove old blackjok3r's wallet filter code.
- wallet filter: new wallet filter implementation, key difference - now if enabled it allows txes not only from notary address and addresses listed in `-whitelistaddress`, but also from all addresses belongs to a walelt. in other words - if any addresses passed via `-whitelistaddress`, wf is enabled and allows txes only from addresses that belongs to wallet and white-listed addresses. be aware to use wf on z-tx (private tx) enabled chains, bcz it possible can reject tx from z->t. it designed only for ac_public chains only and KMD itself.
- code refactoring: remove creatsig error message and keystore.%p error message on stderr.
- rpc: work-around an upstream libevent bug
- GH actions: fixed windows and linux build (removed php7.4-fpm package)
- code refactoring: remove dead code in init
- CVE-2018–20586 fix