### PR TITLE
komodod test builds CD pipeline

### DIFF
--- a/.github/workflows/komodod_cd.yml
+++ b/.github/workflows/komodod_cd.yml
@@ -1,0 +1,178 @@
+# we are using separate workflow because CI producing test binaries with CPPFLAGS=-DTESTMODE
+
+name: Komodo CD test releases
+
+
+on:
+  push:
+    branches:
+    - beta
+    - dev
+    - research
+
+
+jobs:
+
+  linux-build:
+    name: Linux Build
+    # using there as old release as possible with GHA worker to provide better compatibility
+    runs-on: ubuntu-16.04
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install deps (Linux)
+        run: |
+          sudo apt-get remove php7.1-fpm php7.2-fpm php7.3-fpm php7.3-common php7.4-fpm msodbcsql17
+          sudo apt-get update
+          sudo apt-get upgrade -y
+          sudo apt-get update
+          sudo apt-get install -q \
+                 curl \
+                 python3 \
+                 python3-dev \
+                 python3-setuptools \
+                 python3-pip \
+                 libcurl4-openssl-dev \
+                 libssl-dev -y
+          ./zcutil/fetch-params.sh
+              
+      - name: Build (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          ./zcutil/build.sh -j$(nproc)
+          zip --junk-paths komodo-linux src/komodod src/komodo-cli
+      - name: Upload komodo-linux.zip as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: komodo-linux
+          path: ./komodo-linux.zip
+
+  osx-build:
+    name: OSX Build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps (macOS)
+        run: |
+          brew update
+          brew upgrade
+          brew tap discoteq/discoteq; brew install flock
+          brew install autoconf autogen automake
+          brew install gcc@8
+          brew install binutils
+          brew install protobuf
+          brew install coreutils
+          brew install wget
+          brew install python3
+          pip3 install setuptools wheel slick-bitcoinrpc pytest wget
+          ./zcutil/fetch-params.sh
+      - name: Build (macOS)
+        run: |
+          ./zcutil/build-mac.sh -j4
+          zip --junk-paths komodo-osx src/komodod src/komodo-cli
+      - name: Upload komodo-osx.zip as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: komodo-osx
+          path: ./komodo-osx.zip
+
+  windows-build:
+    name: Windows Build (mingw)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps (Windows)
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get remove php5.6-fpm php7.0-fpm php7.1-fpm php7.2-fpm php7.3-fpm php7.3-common php7.4-fpm
+          sudo apt-get update
+          sudo apt-get upgrade -y
+          sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool libncurses-dev unzip git python zlib1g-dev wget bsdmainutils automake libboost-all-dev libssl-dev libprotobuf-dev protobuf-compiler libqrencode-dev libdb++-dev ntp ntpdate nano software-properties-common curl libevent-dev libcurl4-gnutls-dev cmake clang libsodium-dev -y
+          sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python python-zmq zlib1g-dev wget libcurl4-gnutls-dev bsdmainutils automake curl cmake mingw-w64
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup target add x86_64-pc-windows-gnu
+          sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
+          sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+      - name: Build (Windows)
+        run: |
+          ./zcutil/build-win.sh -j$(nproc)
+          zip --junk-paths komodo-win src/komodod.exe src/komodo-cli.exe
+      - name: Upload komodo-win.zip as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: komodo-win
+          path: ./komodo-win.zip      
+
+  publish-release:
+      name: Publishing CD releases
+      runs-on: ubuntu-latest
+      needs: [linux-build, osx-build, windows-build]
+      steps:
+        - name: Download komodo-linux.zip
+          uses: actions/download-artifact@v1
+          with:
+            name: komodo-linux  
+        - name: Download komodo-osx.zip
+          uses: actions/download-artifact@v1
+          with:
+            name: komodo-osx
+        - name: Download komodo-win.zip
+          uses: actions/download-artifact@v1
+          with:
+            name: komodo-win
+
+        - name: Extract branch name
+          shell: bash
+          run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+          id: extract_branch
+
+        - name: Shortify commit sha
+          shell: bash
+          run: echo "##[set-output name=sha_short;]$(echo ${GITHUB_SHA::7})"
+          id: shortify_commit
+
+        - name: Create Release
+          id: create_release
+          uses: actions/create-release@latest
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            tag_name: cd_release_${{ steps.shortify_commit.outputs.sha_short }}_${{ steps.extract_branch.outputs.branch }}
+            release_name: CD Release ${{ steps.shortify_commit.outputs.sha_short }} ${{ steps.extract_branch.outputs.branch }}
+            draft: false
+            prerelease: true
+        - name: Upload Linux Release Asset
+          id: upload-linux-release-asset 
+          uses: actions/upload-release-asset@latest
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+            asset_path: komodo-linux/komodo-linux.zip
+            asset_name: komodo_${{ steps.shortify_commit.outputs.sha_short }}_${{ steps.extract_branch.outputs.branch }}_linux.zip
+            asset_content_type: application/zip
+        - name: Upload OSX Release Asset
+          id: upload-osx-release-asset 
+          uses: actions/upload-release-asset@latest
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+            asset_path: komodo-osx/komodo-osx.zip
+            asset_name: komodo_${{ steps.shortify_commit.outputs.sha_short }}_${{ steps.extract_branch.outputs.branch }}_osx.zip
+            asset_content_type: application/zip
+        - name: Upload Windows Release Asset
+          id: upload-windows-release-asset 
+          uses: actions/upload-release-asset@latest
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+            asset_path: komodo-win/komodo-win.zip
+            asset_name: komodo_${{ steps.shortify_commit.outputs.sha_short }}_${{ steps.extract_branch.outputs.branch }}_win.zip
+            asset_content_type: application/zip


### PR DESCRIPTION
Komodod CD workflow for GHA 
building and pushing multiOS release (Ubuntu, OSX, Windows) for pushes to branches beta, dev, research

example of autogenerated release by this flow:
https://github.com/tonymorony/komodo/releases/tag/cd_release_90f7b49_dev