### PR TITLE
komodod docker image publishing in CD

### DIFF
--- a/.github/workflows/komodod_cd.yml
+++ b/.github/workflows/komodod_cd.yml
@@ -19,6 +19,16 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
 
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
+      - name: Shortify commit sha
+        shell: bash
+        run: echo "##[set-output name=sha_short;]$(echo ${GITHUB_SHA::7})"
+        id: shortify_commit
+
       - name: Checkout code
         uses: actions/checkout@v2
 
@@ -37,7 +47,6 @@ jobs:
                  libcurl4-openssl-dev \
                  libssl-dev -y
           ./zcutil/fetch-params.sh
-              
       - name: Build (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -48,6 +57,20 @@ jobs:
         with:
           name: komodo-linux
           path: ./komodo-linux.zip
+
+      - name: Login to docker hub
+        uses: actions-hub/docker/login@master
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build container
+        run: docker build -f Dockerfile.release -t komodoofficial/komodo:cd_release_${{ steps.shortify_commit.outputs.sha_short }}_${{ steps.extract_branch.outputs.branch }} .
+
+      - name: Push to docker hub
+        uses: actions-hub/docker@master
+        with:
+          args: push komodoofficial/komodo:cd_release_${{ steps.shortify_commit.outputs.sha_short }}_${{ steps.extract_branch.outputs.branch }}
 
   osx-build:
     name: OSX Build

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,8 @@
+FROM ubuntu:18.04
+RUN \ 
+    apt-get update &&\
+    apt-get install -y libgomp1
+CMD mkdir /komodo
+WORKDIR /komodo
+COPY src/komodod src/komodo-cli ./
+CMD ./komodod


### PR DESCRIPTION
Images will be published by GHA CD into https://hub.docker.com/repository/docker/komodoofficial/komodo repo with the same tag as GH CD release.

Image is just Ubuntu 18.04 (used it as an current most used LTE) with komodod and komodo-cli in /komodo folder (readme will be added to docker repo)

Example of docker images pushed by CD into my repo: https://hub.docker.com/repository/docker/tonymorony/komodod-test
Example of GHA run: https://github.com/tonymorony/komodo/runs/519052624
Example of image usage: https://github.com/tonymorony/komodo_docker_tests/blob/master/Dockerfile.blockchain#L1