### PR TITLE
fix linearize tool to get it work with Komodo

### DIFF
--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -1,33 +1,54 @@
 # Linearize
-Construct a linear, no-fork, best version of the blockchain.
+Construct a linear, no-fork, best version of the Komodo  (or smartchain) blockchain.
 
 ## Step 1: Download hash list
 
     $ ./linearize-hashes.py linearize.cfg > hashlist.txt
 
 Required configuration file settings for linearize-hashes:
-* RPC: rpcuser, rpcpassword
+* RPC: `datadir` (Required if `rpcuser` and `rpcpassword` are not specified)
+* RPC: `rpcuser`, `rpcpassword` (Required if `datadir` is not specified)
 
 Optional config file setting for linearize-hashes:
-* RPC: host, port
-* Block chain: min_height, max_height
+* RPC: `host`  (Default: `127.0.0.1`)
+* RPC: `port`  (Default: `7771`)
+* Blockchain: `min_height`, `max_height`
+* `rev_hash_bytes`: If true, the written block hash list will be
+byte-reversed. (In other words, the hash returned by getblockhash will have its
+bytes reversed.) False by default. Intended for generation of
+standalone hash lists but safe to use with linearize-data.py, which will output
+the same data no matter which byte format is chosen.
+
+The `linearize-hashes` script requires a connection, local or remote, to a
+JSON-RPC server. Running `komodod` or `komodo-qt -server` will be sufficient.
 
 ## Step 2: Copy local block data
 
     $ ./linearize-data.py linearize.cfg
 
 Required configuration file settings:
-* "input": bitcoind blocks/ directory containing blkNNNNN.dat
-* "hashlist": text file containing list of block hashes, linearized-hashes.py
-output.
-* "output_file": bootstrap.dat
+* `output_file`: The file that will contain the final blockchain.
       or
-* "output": output directory for linearized blocks/blkNNNNN.dat output
+* `output`: Output directory for linearized `blocks/blkNNNNN.dat` output.
 
 Optional config file setting for linearize-data:
-* "netmagic": network magic number
-* "max_out_sz": maximum output file size (default `1000*1000*1000`)
-* "split_timestamp": Split files when a new month is first seen, in addition to
-reaching a maximum file size.
-* "file_timestamp": Set each file's last-modified time to that of the
-most recent block in that file.
+* `debug_output`: Some printouts may not always be desired. If true, such output
+will be printed.
+* `file_timestamp`: Set each file's last-accessed and last-modified times,
+respectively, to the current time and to the timestamp of the most recent block
+written to the script's blockchain.
+* `genesis`: The hash of the genesis block in the blockchain.
+* `input`: komodod blocks/ directory containing blkNNNNN.dat
+* `hashlist`: text file containing list of block hashes created by
+linearize-hashes.py.
+* `max_out_sz`: Maximum size for files created by the `output_file` option.
+(Default: `1000*1000*1000 bytes`)
+* `netmagic`: Network magic number.
+* `out_of_order_cache_sz`: If out-of-order blocks are being read, the block can
+be written to a cache so that the blockchain doesn't have to be sought again.
+This option specifies the cache size. (Default: `100*1000*1000 bytes`)
+* `rev_hash_bytes`: If true, the block hash list written by linearize-hashes.py
+will be byte-reversed when read by linearize-data.py. See the linearize-hashes
+entry for more information.
+* `split_timestamp`: Split blockchain files when a new month is first seen, in
+addition to reaching a maximum file size (`max_out_sz`).

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -1,29 +1,55 @@
-
 # bitcoind RPC settings (linearize-hashes)
-rpcuser=someuser
-rpcpassword=somepassword
+rpcuser=bitcoin
+rpcpassword=local321
+datadir=~/.komodo
 host=127.0.0.1
-port=8232
-#port=18232
+
+#mainnet default
+port=7771
+
+#testnet default
+#port=18332
+
+#regtest default
+#port=18443
 
 # bootstrap.dat hashlist settings (linearize-hashes)
-max_height=313000
+max_height=1844224
 
 # bootstrap.dat input/output settings (linearize-data)
 
 # mainnet
-netmagic=f9beb4d9
-genesis=000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-input=/home/example/.bitcoin/blocks
+netmagic=f9eee48d
+genesis=027e3758c3a65b12aa1046462b486d0a63bfa1beae327897f56c5cfb7daaae71
+input=/home/decker/.komodo/blocks
 
 # testnet
 #netmagic=0b110907
 #genesis=000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
 #input=/home/example/.bitcoin/testnet3/blocks
 
-output_file=/home/example/Downloads/bootstrap.dat
-hashlist=hashlist.txt
-split_year=1
+# regtest
+#netmagic=fabfb5da
+#genesis=0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
+#input=/home/example/.bitcoin/regtest/blocks
 
-# Maxmimum size in bytes of out-of-order blocks cache in memory
+# "output" option causes blockchain files to be written to the given location,
+# with "output_file" ignored. If not used, "output_file" is used instead.
+# output=/home/example/blockchain_directory
+output_file=/home/decker/bootstrap.dat
+hashlist=hashlist.txt
+
+# Maximum size in bytes of out-of-order blocks cache in memory
 out_of_order_cache_sz = 100000000
+
+# Do we want the reverse the hash bytes coming from getblockhash?
+rev_hash_bytes = False
+
+# On a new month, do we want to set the access and modify times of the new
+# blockchain file?
+file_timestamp = 0
+# Do we want to split the blockchain files given a new month or specific height?
+split_timestamp = 0
+
+# Do we want debug printouts?
+debug_output = False

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -1,303 +1,351 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # linearize-data.py: Construct a linear, no-fork version of the chain.
 #
-# Copyright (c) 2013-2014 The Bitcoin Core developers
+# Copyright (c) 2013-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 
-from __future__ import print_function, division
-import json
 import struct
 import re
 import os
 import os.path
-import base64
-import httplib
 import sys
 import hashlib
 import datetime
 import time
+import glob
 from collections import namedtuple
+from binascii import unhexlify
 
 settings = {}
 
+def hex_switchEndian(s):
+    """ Switches the endianness of a hex string (in pairs of hex chars) """
+    pairList = [s[i:i+2].encode() for i in range(0, len(s), 2)]
+    return b''.join(pairList[::-1]).decode()
+
 def uint32(x):
-	return x & 0xffffffffL
+    return x & 0xffffffff
 
 def bytereverse(x):
-	return uint32(( ((x) << 24) | (((x) << 8) & 0x00ff0000) |
-		       (((x) >> 8) & 0x0000ff00) | ((x) >> 24) ))
+    return uint32(( ((x) << 24) | (((x) << 8) & 0x00ff0000) |
+               (((x) >> 8) & 0x0000ff00) | ((x) >> 24) ))
 
 def bufreverse(in_buf):
-	out_words = []
-	for i in range(0, len(in_buf), 4):
-		word = struct.unpack('@I', in_buf[i:i+4])[0]
-		out_words.append(struct.pack('@I', bytereverse(word)))
-	return ''.join(out_words)
+    out_words = []
+    for i in range(0, len(in_buf), 4):
+        word = struct.unpack('@I', in_buf[i:i+4])[0]
+        out_words.append(struct.pack('@I', bytereverse(word)))
+    return b''.join(out_words)
 
 def wordreverse(in_buf):
-	out_words = []
-	for i in range(0, len(in_buf), 4):
-		out_words.append(in_buf[i:i+4])
-	out_words.reverse()
-	return ''.join(out_words)
+    out_words = []
+    for i in range(0, len(in_buf), 4):
+        out_words.append(in_buf[i:i+4])
+    out_words.reverse()
+    return b''.join(out_words)
 
 def calc_hdr_hash(blk_hdr):
-	hash1 = hashlib.sha256()
-	hash1.update(blk_hdr)
-	hash1_o = hash1.digest()
+    hash1 = hashlib.sha256()
+    hash1.update(blk_hdr)
+    hash1_o = hash1.digest()
 
-	hash2 = hashlib.sha256()
-	hash2.update(hash1_o)
-	hash2_o = hash2.digest()
+    hash2 = hashlib.sha256()
+    hash2.update(hash1_o)
+    hash2_o = hash2.digest()
 
-	return hash2_o
+    return hash2_o
 
 def calc_hash_str(blk_hdr):
-	hash = calc_hdr_hash(blk_hdr)
-	hash = bufreverse(hash)
-	hash = wordreverse(hash)
-	hash_str = hash.encode('hex')
-	return hash_str
+    hash = calc_hdr_hash(blk_hdr)
+    hash = bufreverse(hash)
+    hash = wordreverse(hash)
+    hash_str = hash.hex()
+    return hash_str
 
 def get_blk_dt(blk_hdr):
-	members = struct.unpack("<I", blk_hdr[68:68+4])
-	nTime = members[0]
-	dt = datetime.datetime.fromtimestamp(nTime)
-	dt_ym = datetime.datetime(dt.year, dt.month, 1)
-	return (dt_ym, nTime)
+    members = struct.unpack("<I", blk_hdr[68:68+4])
+    nTime = members[0]
+    dt = datetime.datetime.fromtimestamp(nTime)
+    dt_ym = datetime.datetime(dt.year, dt.month, 1)
+    return (dt_ym, nTime)
 
+# When getting the list of block hashes, undo any byte reversals.
 def get_block_hashes(settings):
-	blkindex = []
-	f = open(settings['hashlist'], "r")
-	for line in f:
-		line = line.rstrip()
-		blkindex.append(line)
+    blkindex = []
+    f = open(settings['hashlist'], "r", encoding="utf8")
+    for line in f:
+        line = line.rstrip()
+        if settings['rev_hash_bytes'] == 'true':
+            line = hex_switchEndian(line)
+        blkindex.append(line)
 
-	print("Read " + str(len(blkindex)) + " hashes")
+    print("Read " + str(len(blkindex)) + " hashes")
 
-	return blkindex
+    return blkindex
 
+# The block map shouldn't give or receive byte-reversed hashes.
 def mkblockmap(blkindex):
-	blkmap = {}
-	for height,hash in enumerate(blkindex):
-		blkmap[hash] = height
-	return blkmap
+    blkmap = {}
+    for height,hash in enumerate(blkindex):
+        blkmap[hash] = height
+    return blkmap
+
+# This gets the first block file ID that exists from the input block
+# file directory.
+def getFirstBlockFileId(block_dir_path):
+    # First, this sets up a pattern to search for block files, for
+    # example 'blkNNNNN.dat'.
+    blkFilePattern = os.path.join(block_dir_path, "blk[0-9][0-9][0-9][0-9][0-9].dat")
+
+    # This search is done with glob
+    blkFnList = glob.glob(blkFilePattern)
+
+    if len(blkFnList) == 0:
+        print("blocks not pruned - starting at 0")
+        return 0
+    # We then get the lexicographic minimum, which should be the first
+    # block file name.
+    firstBlkFilePath = min(blkFnList)
+    firstBlkFn = os.path.basename(firstBlkFilePath)
+
+    # now, the string should be ['b','l','k','N','N','N','N','N','.','d','a','t']
+    # So get the ID by choosing:              3   4   5   6   7
+    # The ID is not necessarily 0 if this is a pruned node.
+    blkId = int(firstBlkFn[3:8])
+    return blkId
 
 # Block header and extent on disk
 BlockExtent = namedtuple('BlockExtent', ['fn', 'offset', 'inhdr', 'blkhdr', 'size'])
 
 class BlockDataCopier:
-	def __init__(self, settings, blkindex, blkmap):
-		self.settings = settings
-		self.blkindex = blkindex
-		self.blkmap = blkmap
+    def __init__(self, settings, blkindex, blkmap):
+        self.settings = settings
+        self.blkindex = blkindex
+        self.blkmap = blkmap
 
-		self.inFn = 0
-		self.inF = None
-		self.outFn = 0
-		self.outsz = 0
-		self.outF = None
-		self.outFname = None
-		self.blkCountIn = 0
-		self.blkCountOut = 0
+        # Get first occurring block file id - for pruned nodes this
+        # will not necessarily be 0
+        self.inFn = getFirstBlockFileId(self.settings['input'])
+        self.inF = None
+        self.outFn = 0
+        self.outsz = 0
+        self.outF = None
+        self.outFname = None
+        self.blkCountIn = 0
+        self.blkCountOut = 0
 
-		self.lastDate = datetime.datetime(2000, 1, 1)
-		self.highTS = 1408893517 - 315360000
-		self.timestampSplit = False
-		self.fileOutput = True
-		self.setFileTime = False
-		self.maxOutSz = settings['max_out_sz']
-		if 'output' in settings:
-			self.fileOutput = False
-		if settings['file_timestamp'] != 0:
-			self.setFileTime = True
-		if settings['split_timestamp'] != 0:
-			self.timestampSplit = True
-		# Extents and cache for out-of-order blocks
-		self.blockExtents = {}
-		self.outOfOrderData = {}
-		self.outOfOrderSize = 0 # running total size for items in outOfOrderData
+        self.lastDate = datetime.datetime(2000, 1, 1)
+        self.highTS = 1408893517 - 315360000
+        self.timestampSplit = False
+        self.fileOutput = True
+        self.setFileTime = False
+        self.maxOutSz = settings['max_out_sz']
+        if 'output' in settings:
+            self.fileOutput = False
+        if settings['file_timestamp'] != 0:
+            self.setFileTime = True
+        if settings['split_timestamp'] != 0:
+            self.timestampSplit = True
+        # Extents and cache for out-of-order blocks
+        self.blockExtents = {}
+        self.outOfOrderData = {}
+        self.outOfOrderSize = 0 # running total size for items in outOfOrderData
 
-	def writeBlock(self, inhdr, blk_hdr, rawblock):
-		blockSizeOnDisk = len(inhdr) + len(blk_hdr) + len(rawblock)
-		if not self.fileOutput and ((self.outsz + blockSizeOnDisk) > self.maxOutSz):
-			self.outF.close()
-			if self.setFileTime:
-				os.utime(outFname, (int(time.time()), highTS))
-			self.outF = None
-			self.outFname = None
-			self.outFn = self.outFn + 1
-			self.outsz = 0
+    def writeBlock(self, inhdr, blk_hdr, rawblock):
+        blockSizeOnDisk = len(inhdr) + len(blk_hdr) + len(rawblock)
+        if not self.fileOutput and ((self.outsz + blockSizeOnDisk) > self.maxOutSz):
+            self.outF.close()
+            if self.setFileTime:
+                os.utime(self.outFname, (int(time.time()), self.highTS))
+            self.outF = None
+            self.outFname = None
+            self.outFn = self.outFn + 1
+            self.outsz = 0
 
-		(blkDate, blkTS) = get_blk_dt(blk_hdr)
-		if self.timestampSplit and (blkDate > self.lastDate):
-			print("New month " + blkDate.strftime("%Y-%m") + " @ " + hash_str)
-			lastDate = blkDate
-			if outF:
-				outF.close()
-				if setFileTime:
-					os.utime(outFname, (int(time.time()), highTS))
-				self.outF = None
-				self.outFname = None
-				self.outFn = self.outFn + 1
-				self.outsz = 0
+        (blkDate, blkTS) = get_blk_dt(blk_hdr)
+        if self.timestampSplit and (blkDate > self.lastDate):
+            print("New month " + blkDate.strftime("%Y-%m") + " @ " + self.hash_str)
+            self.lastDate = blkDate
+            if self.outF:
+                self.outF.close()
+                if self.setFileTime:
+                    os.utime(self.outFname, (int(time.time()), self.highTS))
+                self.outF = None
+                self.outFname = None
+                self.outFn = self.outFn + 1
+                self.outsz = 0
 
-		if not self.outF:
-			if self.fileOutput:
-				outFname = self.settings['output_file']
-			else:
-				outFname = os.path.join(self.settings['output'], "blk%05d.dat" % self.outFn)
-			print("Output file " + outFname)
-			self.outF = open(outFname, "wb")
+        if not self.outF:
+            if self.fileOutput:
+                self.outFname = self.settings['output_file']
+            else:
+                self.outFname = os.path.join(self.settings['output'], "blk%05d.dat" % self.outFn)
+            print("Output file " + self.outFname)
+            self.outF = open(self.outFname, "wb")
 
-		self.outF.write(inhdr)
-		self.outF.write(blk_hdr)
-		self.outF.write(rawblock)
-		self.outsz = self.outsz + len(inhdr) + len(blk_hdr) + len(rawblock)
+        self.outF.write(inhdr)
+        self.outF.write(blk_hdr)
+        self.outF.write(rawblock)
+        self.outsz = self.outsz + len(inhdr) + len(blk_hdr) + len(rawblock)
 
-		self.blkCountOut = self.blkCountOut + 1
-		if blkTS > self.highTS:
-			self.highTS = blkTS
+        self.blkCountOut = self.blkCountOut + 1
+        if blkTS > self.highTS:
+            self.highTS = blkTS
 
-		if (self.blkCountOut % 1000) == 0:
-			print('%i blocks scanned, %i blocks written (of %i, %.1f%% complete)' % 
-					(self.blkCountIn, self.blkCountOut, len(self.blkindex), 100.0 * self.blkCountOut / len(self.blkindex)))
+        if (self.blkCountOut % 1000) == 0:
+            print('%i blocks scanned, %i blocks written (of %i, %.1f%% complete)' %
+                    (self.blkCountIn, self.blkCountOut, len(self.blkindex), 100.0 * self.blkCountOut / len(self.blkindex)))
 
-	def inFileName(self, fn):
-		return os.path.join(self.settings['input'], "blk%05d.dat" % fn)
+    def inFileName(self, fn):
+        return os.path.join(self.settings['input'], "blk%05d.dat" % fn)
 
-	def fetchBlock(self, extent):
-		'''Fetch block contents from disk given extents'''
-		with open(self.inFileName(extent.fn), "rb") as f:
-			f.seek(extent.offset)
-			return f.read(extent.size)
+    def fetchBlock(self, extent):
+        '''Fetch block contents from disk given extents'''
+        with open(self.inFileName(extent.fn), "rb") as f:
+            f.seek(extent.offset)
+            return f.read(extent.size)
 
-	def copyOneBlock(self):
-		'''Find the next block to be written in the input, and copy it to the output.'''
-		extent = self.blockExtents.pop(self.blkCountOut)
-		if self.blkCountOut in self.outOfOrderData:
-			# If the data is cached, use it from memory and remove from the cache
-			rawblock = self.outOfOrderData.pop(self.blkCountOut)
-			self.outOfOrderSize -= len(rawblock)
-		else: # Otherwise look up data on disk
-			rawblock = self.fetchBlock(extent)
+    def copyOneBlock(self):
+        '''Find the next block to be written in the input, and copy it to the output.'''
+        extent = self.blockExtents.pop(self.blkCountOut)
+        if self.blkCountOut in self.outOfOrderData:
+            # If the data is cached, use it from memory and remove from the cache
+            rawblock = self.outOfOrderData.pop(self.blkCountOut)
+            self.outOfOrderSize -= len(rawblock)
+        else: # Otherwise look up data on disk
+            rawblock = self.fetchBlock(extent)
 
-		self.writeBlock(extent.inhdr, extent.blkhdr, rawblock)
+        self.writeBlock(extent.inhdr, extent.blkhdr, rawblock)
 
-	def run(self):
-		while self.blkCountOut < len(self.blkindex):
-			if not self.inF:
-				fname = self.inFileName(self.inFn)
-				print("Input file " + fname)
-				try:
-					self.inF = open(fname, "rb")
-				except IOError:
-					print("Premature end of block data")
-					return
+    def run(self):
+        while self.blkCountOut < len(self.blkindex):
+            if not self.inF:
+                fname = self.inFileName(self.inFn)
+                print("Input file " + fname)
+                try:
+                    self.inF = open(fname, "rb")
+                except IOError:
+                    print("Premature end of block data")
+                    return
 
-			inhdr = self.inF.read(8)
-			if (not inhdr or (inhdr[0] == "\0")):
-				self.inF.close()
-				self.inF = None
-				self.inFn = self.inFn + 1
-				continue
+            inhdr = self.inF.read(8)
+            if (not inhdr or (inhdr[0] == "\0")):
+                self.inF.close()
+                self.inF = None
+                self.inFn = self.inFn + 1
+                continue
 
-			inMagic = inhdr[:4]
-			if (inMagic != self.settings['netmagic']):
-				print("Invalid magic: " + inMagic.encode('hex'))
-				return
-			inLenLE = inhdr[4:]
-			su = struct.unpack("<I", inLenLE)
-			inLen = su[0] - 80 # length without header
-			blk_hdr = self.inF.read(80)
-			inExtent = BlockExtent(self.inFn, self.inF.tell(), inhdr, blk_hdr, inLen)
+            inMagic = inhdr[:4]
+            if (inMagic != self.settings['netmagic']):
+                # Seek backwards 7 bytes (skipping the first byte in the previous search)
+                # and continue searching from the new position if the magic bytes are not
+                # found.
+                self.inF.seek(-7, os.SEEK_CUR)
+                continue
+            inLenLE = inhdr[4:]
+            su = struct.unpack("<I", inLenLE)
+            inLen = su[0] - 1487 # length without header
+            blk_hdr = self.inF.read(1487)
+            inExtent = BlockExtent(self.inFn, self.inF.tell(), inhdr, blk_hdr, inLen)
 
-			hash_str = calc_hash_str(blk_hdr)
-			if not hash_str in blkmap:
-				print("Skipping unknown block " + hash_str)
-				self.inF.seek(inLen, os.SEEK_CUR)
-				continue
+            self.hash_str = calc_hash_str(blk_hdr)
 
-			blkHeight = self.blkmap[hash_str]
-			self.blkCountIn += 1
+            if not self.hash_str in blkmap:
+                # Because blocks can be written to files out-of-order as of 0.10, the script
+                # may encounter blocks it doesn't know about. Treat as debug output.
+                if settings['debug_output'] == 'true':
+                    print("Skipping unknown block " + self.hash_str)
+                self.inF.seek(inLen, os.SEEK_CUR)
+                continue
 
-			if self.blkCountOut == blkHeight:
-				# If in-order block, just copy
-				rawblock = self.inF.read(inLen)
-				self.writeBlock(inhdr, blk_hdr, rawblock)
+            blkHeight = self.blkmap[self.hash_str]
+            self.blkCountIn += 1
 
-				# See if we can catch up to prior out-of-order blocks
-				while self.blkCountOut in self.blockExtents:
-					self.copyOneBlock()
+            if self.blkCountOut == blkHeight:
+                # If in-order block, just copy
+                rawblock = self.inF.read(inLen)
+                self.writeBlock(inhdr, blk_hdr, rawblock)
 
-			else: # If out-of-order, skip over block data for now
-				self.blockExtents[blkHeight] = inExtent
-				if self.outOfOrderSize < self.settings['out_of_order_cache_sz']:
-					# If there is space in the cache, read the data
-					# Reading the data in file sequence instead of seeking and fetching it later is preferred,
-					# but we don't want to fill up memory
-					self.outOfOrderData[blkHeight] = self.inF.read(inLen)
-					self.outOfOrderSize += inLen
-				else: # If no space in cache, seek forward
-					self.inF.seek(inLen, os.SEEK_CUR)
+                # See if we can catch up to prior out-of-order blocks
+                while self.blkCountOut in self.blockExtents:
+                    self.copyOneBlock()
 
-		print("Done (%i blocks written)" % (self.blkCountOut))
+            else: # If out-of-order, skip over block data for now
+                self.blockExtents[blkHeight] = inExtent
+                if self.outOfOrderSize < self.settings['out_of_order_cache_sz']:
+                    # If there is space in the cache, read the data
+                    # Reading the data in file sequence instead of seeking and fetching it later is preferred,
+                    # but we don't want to fill up memory
+                    self.outOfOrderData[blkHeight] = self.inF.read(inLen)
+                    self.outOfOrderSize += inLen
+                else: # If no space in cache, seek forward
+                    self.inF.seek(inLen, os.SEEK_CUR)
+
+        print("Done (%i blocks written)" % (self.blkCountOut))
 
 if __name__ == '__main__':
-	if len(sys.argv) != 2:
-		print("Usage: linearize-data.py CONFIG-FILE")
-		sys.exit(1)
+    if len(sys.argv) != 2:
+        print("Usage: linearize-data.py CONFIG-FILE")
+        sys.exit(1)
 
-	f = open(sys.argv[1])
-	for line in f:
-		# skip comment lines
-		m = re.search('^\s*#', line)
-		if m:
-			continue
+    f = open(sys.argv[1], encoding="utf8")
+    for line in f:
+        # skip comment lines
+        m = re.search(r'^\s*#', line)
+        if m:
+            continue
 
-		# parse key=value lines
-		m = re.search('^(\w+)\s*=\s*(\S.*)$', line)
-		if m is None:
-			continue
-		settings[m.group(1)] = m.group(2)
-	f.close()
+        # parse key=value lines
+        m = re.search(r'^(\w+)\s*=\s*(\S.*)$', line)
+        if m is None:
+            continue
+        settings[m.group(1)] = m.group(2)
+    f.close()
 
-	if 'netmagic' not in settings:
-		settings['netmagic'] = 'f9beb4d9'
-	if 'genesis' not in settings:
-		settings['genesis'] = '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f'
-	if 'input' not in settings:
-		settings['input'] = 'input'
-	if 'hashlist' not in settings:
-		settings['hashlist'] = 'hashlist.txt'
-	if 'file_timestamp' not in settings:
-		settings['file_timestamp'] = 0
-	if 'split_timestamp' not in settings:
-		settings['split_timestamp'] = 0
-	if 'max_out_sz' not in settings:
-		settings['max_out_sz'] = 1000L * 1000 * 1000
-	if 'out_of_order_cache_sz' not in settings:
-		settings['out_of_order_cache_sz'] = 100 * 1000 * 1000
+    # Force hash byte format setting to be lowercase to make comparisons easier.
+    # Also place upfront in case any settings need to know about it.
+    if 'rev_hash_bytes' not in settings:
+        settings['rev_hash_bytes'] = 'false'
+    settings['rev_hash_bytes'] = settings['rev_hash_bytes'].lower()
 
-	settings['max_out_sz'] = long(settings['max_out_sz'])
-	settings['split_timestamp'] = int(settings['split_timestamp'])
-	settings['file_timestamp'] = int(settings['file_timestamp'])
-	settings['netmagic'] = settings['netmagic'].decode('hex')
-	settings['out_of_order_cache_sz'] = int(settings['out_of_order_cache_sz'])
+    if 'netmagic' not in settings:
+        settings['netmagic'] = 'f9eee48d'
+    if 'genesis' not in settings:
+        settings['genesis'] = '027e3758c3a65b12aa1046462b486d0a63bfa1beae327897f56c5cfb7daaae71'
+    if 'input' not in settings:
+        settings['input'] = 'input'
+    if 'hashlist' not in settings:
+        settings['hashlist'] = 'hashlist.txt'
+    if 'file_timestamp' not in settings:
+        settings['file_timestamp'] = 0
+    if 'split_timestamp' not in settings:
+        settings['split_timestamp'] = 0
+    if 'max_out_sz' not in settings:
+        settings['max_out_sz'] = 1000 * 1000 * 1000
+    if 'out_of_order_cache_sz' not in settings:
+        settings['out_of_order_cache_sz'] = 100 * 1000 * 1000
+    if 'debug_output' not in settings:
+        settings['debug_output'] = 'false'
 
-	if 'output_file' not in settings and 'output' not in settings:
-		print("Missing output file / directory")
-		sys.exit(1)
+    settings['max_out_sz'] = int(settings['max_out_sz'])
+    settings['split_timestamp'] = int(settings['split_timestamp'])
+    settings['file_timestamp'] = int(settings['file_timestamp'])
+    settings['netmagic'] = unhexlify(settings['netmagic'].encode('utf-8'))
+    settings['out_of_order_cache_sz'] = int(settings['out_of_order_cache_sz'])
+    settings['debug_output'] = settings['debug_output'].lower()
 
-	blkindex = get_block_hashes(settings)
-	blkmap = mkblockmap(blkindex)
+    if 'output_file' not in settings and 'output' not in settings:
+        print("Missing output file / directory")
+        sys.exit(1)
 
-	if not settings['genesis'] in blkmap:
-		print("Genesis block not found in hashlist")
-	else:
-		BlockDataCopier(settings, blkindex, blkmap).run()
+    blkindex = get_block_hashes(settings)
+    blkmap = mkblockmap(blkindex)
 
-
+    # Block hash map won't be byte-reversed. Neither should the genesis hash.
+    if not settings['genesis'] in blkmap:
+        print("Genesis block not found in hashlist")
+    else:
+        BlockDataCopier(settings, blkindex, blkmap).run()

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -1,113 +1,152 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # linearize-hashes.py:  List blocks in a linear, no-fork version of the chain.
 #
-# Copyright (c) 2013-2014 The Bitcoin Core developers
+# Copyright (c) 2013-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 
-from __future__ import print_function
+from http.client import HTTPConnection
 import json
-import struct
 import re
 import base64
-import httplib
 import sys
+import os
+import os.path
 
 settings = {}
 
+def hex_switchEndian(s):
+    """ Switches the endianness of a hex string (in pairs of hex chars) """
+    pairList = [s[i:i+2].encode() for i in range(0, len(s), 2)]
+    return b''.join(pairList[::-1]).decode()
+
 class BitcoinRPC:
-	def __init__(self, host, port, username, password):
-		authpair = "%s:%s" % (username, password)
-		self.authhdr = "Basic %s" % (base64.b64encode(authpair))
-		self.conn = httplib.HTTPConnection(host, port, False, 30)
+    def __init__(self, host, port, username, password):
+        authpair = "%s:%s" % (username, password)
+        authpair = authpair.encode('utf-8')
+        self.authhdr = b"Basic " + base64.b64encode(authpair)
+        self.conn = HTTPConnection(host, port=port, timeout=30)
 
-	def execute(self, obj):
-		self.conn.request('POST', '/', json.dumps(obj),
-			{ 'Authorization' : self.authhdr,
-			  'Content-type' : 'application/json' })
+    def execute(self, obj):
+        try:
+            self.conn.request('POST', '/', json.dumps(obj),
+                { 'Authorization' : self.authhdr,
+                  'Content-type' : 'application/json' })
+        except ConnectionRefusedError:
+            print('RPC connection refused. Check RPC settings and the server status.',
+                  file=sys.stderr)
+            return None
 
-		resp = self.conn.getresponse()
-		if resp is None:
-			print("JSON-RPC: no response", file=sys.stderr)
-			return None
+        resp = self.conn.getresponse()
+        if resp is None:
+            print("JSON-RPC: no response", file=sys.stderr)
+            return None
 
-		body = resp.read()
-		resp_obj = json.loads(body)
-		return resp_obj
+        body = resp.read().decode('utf-8')
+        resp_obj = json.loads(body)
+        return resp_obj
 
-	@staticmethod
-	def build_request(idx, method, params):
-		obj = { 'version' : '1.1',
-			'method' : method,
-			'id' : idx }
-		if params is None:
-			obj['params'] = []
-		else:
-			obj['params'] = params
-		return obj
+    @staticmethod
+    def build_request(idx, method, params):
+        obj = { 'version' : '1.1',
+            'method' : method,
+            'id' : idx }
+        if params is None:
+            obj['params'] = []
+        else:
+            obj['params'] = params
+        return obj
 
-	@staticmethod
-	def response_is_error(resp_obj):
-		return 'error' in resp_obj and resp_obj['error'] is not None
+    @staticmethod
+    def response_is_error(resp_obj):
+        return 'error' in resp_obj and resp_obj['error'] is not None
 
 def get_block_hashes(settings, max_blocks_per_call=10000):
-	rpc = BitcoinRPC(settings['host'], settings['port'],
-			 settings['rpcuser'], settings['rpcpassword'])
+    rpc = BitcoinRPC(settings['host'], settings['port'],
+             settings['rpcuser'], settings['rpcpassword'])
 
-	height = settings['min_height']
-	while height < settings['max_height']+1:
-		num_blocks = min(settings['max_height']+1-height, max_blocks_per_call)
-		batch = []
-		for x in range(num_blocks):
-			batch.append(rpc.build_request(x, 'getblockhash', [height + x]))
+    height = settings['min_height']
+    while height < settings['max_height']+1:
+        num_blocks = min(settings['max_height']+1-height, max_blocks_per_call)
+        batch = []
+        for x in range(num_blocks):
+            batch.append(rpc.build_request(x, 'getblockhash', [height + x]))
 
-		reply = rpc.execute(batch)
+        reply = rpc.execute(batch)
+        if reply is None:
+            print('Cannot continue. Program will halt.')
+            return None
 
-		for x,resp_obj in enumerate(reply):
-			if rpc.response_is_error(resp_obj):
-				print('JSON-RPC: error at height', height+x, ': ', resp_obj['error'], file=sys.stderr)
-				exit(1)
-			assert(resp_obj['id'] == x) # assume replies are in-sequence
-			print(resp_obj['result'])
+        for x,resp_obj in enumerate(reply):
+            if rpc.response_is_error(resp_obj):
+                print('JSON-RPC: error at height', height+x, ': ', resp_obj['error'], file=sys.stderr)
+                sys.exit(1)
+            assert(resp_obj['id'] == x) # assume replies are in-sequence
+            if settings['rev_hash_bytes'] == 'true':
+                resp_obj['result'] = hex_switchEndian(resp_obj['result'])
+            print(resp_obj['result'])
 
-		height += num_blocks
+        height += num_blocks
+
+def get_rpc_cookie():
+    # Open the cookie file
+    with open(os.path.join(os.path.expanduser(settings['datadir']), '.cookie'), 'r', encoding="ascii") as f:
+        combined = f.readline()
+        combined_split = combined.split(":")
+        settings['rpcuser'] = combined_split[0]
+        settings['rpcpassword'] = combined_split[1]
 
 if __name__ == '__main__':
-	if len(sys.argv) != 2:
-		print("Usage: linearize-hashes.py CONFIG-FILE")
-		sys.exit(1)
+    if len(sys.argv) != 2:
+        print("Usage: linearize-hashes.py CONFIG-FILE")
+        sys.exit(1)
 
-	f = open(sys.argv[1])
-	for line in f:
-		# skip comment lines
-		m = re.search('^\s*#', line)
-		if m:
-			continue
+    f = open(sys.argv[1], encoding="utf8")
+    for line in f:
+        # skip comment lines
+        m = re.search(r'^\s*#', line)
+        if m:
+            continue
 
-		# parse key=value lines
-		m = re.search('^(\w+)\s*=\s*(\S.*)$', line)
-		if m is None:
-			continue
-		settings[m.group(1)] = m.group(2)
-	f.close()
+        # parse key=value lines
+        m = re.search(r'^(\w+)\s*=\s*(\S.*)$', line)
+        if m is None:
+            continue
+        settings[m.group(1)] = m.group(2)
+    f.close()
 
-	if 'host' not in settings:
-		settings['host'] = '127.0.0.1'
-	if 'port' not in settings:
-		settings['port'] = 8232
-	if 'min_height' not in settings:
-		settings['min_height'] = 0
-	if 'max_height' not in settings:
-		settings['max_height'] = 313000
-	if 'rpcuser' not in settings or 'rpcpassword' not in settings:
-		print("Missing username and/or password in cfg file", file=stderr)
-		sys.exit(1)
+    if 'host' not in settings:
+        settings['host'] = '127.0.0.1'
+    if 'port' not in settings:
+        settings['port'] = 7771
+    if 'min_height' not in settings:
+        settings['min_height'] = 0
+    if 'max_height' not in settings:
+        settings['max_height'] = 1844224
+    if 'rev_hash_bytes' not in settings:
+        settings['rev_hash_bytes'] = 'false'
 
-	settings['port'] = int(settings['port'])
-	settings['min_height'] = int(settings['min_height'])
-	settings['max_height'] = int(settings['max_height'])
+    use_userpass = True
+    use_datadir = False
+    if 'rpcuser' not in settings or 'rpcpassword' not in settings:
+        use_userpass = False
+    if 'datadir' in settings and not use_userpass:
+        use_datadir = True
+    if not use_userpass and not use_datadir:
+        print("Missing datadir or username and/or password in cfg file", file=sys.stderr)
+        sys.exit(1)
 
-	get_block_hashes(settings)
+    settings['port'] = int(settings['port'])
+    settings['min_height'] = int(settings['min_height'])
+    settings['max_height'] = int(settings['max_height'])
 
+    # Force hash byte format setting to be lowercase to make comparisons easier.
+    settings['rev_hash_bytes'] = settings['rev_hash_bytes'].lower()
+
+    # Get the rpc user and pass from the cookie if the datadir is set
+    if use_datadir:
+        get_rpc_cookie()
+
+    get_block_hashes(settings)


### PR DESCRIPTION
How-to use:

1. Launch Komodo with an rpcuser and rpcpassword set in your config file (komodo.conf)
2. Checkout the Komodo source from Github and cd to contrib/linearize.
3. Copy example-linearize.cfg to linearize.cfg and update it with your rpcuser/rpcpassword values, along with the maximum block height you want to output (max_height), and the path to your data directory (input), as well as the path to your desired output file (output_file).
4. Run `./linearize-hashes.py linearize.cfg > hashlist.txt` followed by .`/linearize-data.py linearize.cfg`.
5. As a result you will get a bootstrap.dat file with following structure:
```
[network number] [length] [block header] [block transactions]
[network number] [length] [block header] [block transactions]
[network number] [length] [block header] [block transactions]
... repeat for all blocks in hashlist.txt
```
Which can be placed to Komodo data folder to load all blocks from file, instead of network.