### PR TITLE
CC_Tokens test - fix error handling

### DIFF
--- a/.github/workflows/komodo_linux_ci.yml
+++ b/.github/workflows/komodo_linux_ci.yml
@@ -2,7 +2,7 @@ name: Komodo Linux CI
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: '0 0 * * 1'
 

--- a/.github/workflows/komodo_mac_ci.yml
+++ b/.github/workflows/komodo_mac_ci.yml
@@ -2,7 +2,7 @@ name: Komodo MacOS CI
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: '0 0 * * 1'
 

--- a/.github/workflows/komodo_win_ci.yml
+++ b/.github/workflows/komodo_win_ci.yml
@@ -2,7 +2,7 @@ name: Komodo Win CI
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: '0 0 * * 1'
 

--- a/qa/pytest_komodo/cc_modules/test_token.py
+++ b/qa/pytest_komodo/cc_modules/test_token.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-# Copyright (c) 2019 SuperNET developers
+# Copyright (c) 2020 SuperNET developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 import pytest
 import time
-
+from slickrpc.exc import RpcException as RPCError
 from util import assert_success, assert_error, mine_and_waitconfirms,\
     send_and_mine, rpc_connect, wait_some_blocks, komodo_teardown
 
@@ -53,8 +53,11 @@ def test_token(test_params):
 #        assert result == []
 
     # trying to create token with negative supply
-    result = rpc.tokencreate("NUKE", "-1987420", "no bueno supply")
-    assert_error(result)
+    try:
+        result = rpc.tokencreate("NUKE", "-1987420", "no bueno supply")
+        assert_error(result)
+    except RPCError as e:
+        assert "Amount out of range" in str(e)
 
     # creating token with name more than 32 chars
     result = rpc.tokencreate("NUKE123456789012345678901234567890", "1987420", "name too long")
@@ -112,8 +115,11 @@ def test_token(test_params):
     assert_error(result)
 
     # invalid price ask
-    result = rpc.tokenask("1", tokenid, "-1")
-    assert_error(result)
+    try:
+        result = rpc.tokenask("1", tokenid, "-1")
+        assert_error(result)
+    except RPCError as e:
+        assert "Amount out of range" in str(e)
 
     # invalid price ask
     result = rpc.tokenask("1", tokenid, "0")
@@ -182,8 +188,11 @@ def test_token(test_params):
     assert_error(result)
 
     # invalid price bid
-    result = rpc.tokenbid("1", tokenid, "-1")
-    assert_error(result)
+    try:
+        result = rpc.tokenbid("1", tokenid, "-1")
+        assert_error(result)
+    except RPCError as e:
+        assert "Amount out of range" in str(e)
 
     # invalid price bid
     result = rpc.tokenbid("1", tokenid, "0")
@@ -205,8 +214,11 @@ def test_token(test_params):
     assert_error(result)
 
     # invalid bid fillunits
-    result = rpc.tokenfillbid(tokenid, tokenbidid, "-777")
-    assert_error(result)
+    try:
+        result = rpc.tokenfillbid(tokenid, tokenbidid, "-777")
+        assert_error(result)
+    except RPCError as e:
+        assert "Amount out of range" in str(e)
 
     # valid bid fillunits
     fillbid = rpc.tokenfillbid(tokenid, tokenbidid, "1000")
@@ -244,8 +256,11 @@ def test_token(test_params):
     assert_error(result)
 
     # invalid token transfer amount (have to add status to CC code!)
-    result = rpc.tokentransfer(tokenid, randompubkey, "-1")
-    assert_error(result)
+    try:
+        result = rpc.tokentransfer(tokenid, randompubkey, "-1")
+        assert_error(result)
+    except RPCError as e:
+        assert "Amount out of range" in str(e)
 
     # valid token transfer
     sendtokens = rpc.tokentransfer(tokenid, randompubkey, "1")

--- a/qa/pytest_komodo/cc_modules/test_token.py
+++ b/qa/pytest_komodo/cc_modules/test_token.py
@@ -53,11 +53,9 @@ def test_token(test_params):
 #        assert result == []
 
     # trying to create token with negative supply
-    try:
+    with pytest.raises(RPCError):
         result = rpc.tokencreate("NUKE", "-1987420", "no bueno supply")
         assert_error(result)
-    except RPCError as e:
-        assert "Amount out of range" in str(e)
 
     # creating token with name more than 32 chars
     result = rpc.tokencreate("NUKE123456789012345678901234567890", "1987420", "name too long")
@@ -115,11 +113,9 @@ def test_token(test_params):
     assert_error(result)
 
     # invalid price ask
-    try:
+    with pytest.raises(RPCError):
         result = rpc.tokenask("1", tokenid, "-1")
         assert_error(result)
-    except RPCError as e:
-        assert "Amount out of range" in str(e)
 
     # invalid price ask
     result = rpc.tokenask("1", tokenid, "0")
@@ -188,11 +184,9 @@ def test_token(test_params):
     assert_error(result)
 
     # invalid price bid
-    try:
+    with pytest.raises(RPCError):
         result = rpc.tokenbid("1", tokenid, "-1")
         assert_error(result)
-    except RPCError as e:
-        assert "Amount out of range" in str(e)
 
     # invalid price bid
     result = rpc.tokenbid("1", tokenid, "0")
@@ -214,11 +208,8 @@ def test_token(test_params):
     assert_error(result)
 
     # invalid bid fillunits
-    try:
-        result = rpc.tokenfillbid(tokenid, tokenbidid, "-777")
-        assert_error(result)
-    except RPCError as e:
-        assert "Amount out of range" in str(e)
+    result = rpc.tokenfillbid(tokenid, tokenbidid, "-777")
+    assert_error(result)
 
     # valid bid fillunits
     fillbid = rpc.tokenfillbid(tokenid, tokenbidid, "1000")
@@ -256,11 +247,8 @@ def test_token(test_params):
     assert_error(result)
 
     # invalid token transfer amount (have to add status to CC code!)
-    try:
-        result = rpc.tokentransfer(tokenid, randompubkey, "-1")
-        assert_error(result)
-    except RPCError as e:
-        assert "Amount out of range" in str(e)
+    result = rpc.tokentransfer(tokenid, randompubkey, "-1")
+    assert_error(result)
 
     # valid token transfer
     sendtokens = rpc.tokentransfer(tokenid, randompubkey, "1")


### PR DESCRIPTION
After latest changes, on negative amounts in rpc calls, JsonRPC error is returned (`Amount out of range`) instead of result json. Fixed error handling/assertion for TokenCC tests.

HeirCC test will still fail, due to actual error in `heirinfo()` calls:

```
'type': 'tokens', 'lifetime': '0', 'available': '0',
```

^^ if heir contract was created with tokens, values above will always return 0 atm.
As far as I'm aware it's known problem being worked on.
Please notify me if an GitHub issue should be made.