### PR TITLE
Cc fingerprint - disable NULL return values when generating fingerprint 

### DIFF
--- a/src/cryptoconditions/src/anon.c
+++ b/src/cryptoconditions/src/anon.c
@@ -53,11 +53,8 @@ static void anonToJSON(const CC *cond, cJSON *params) {
 }
 
 
-static unsigned char *anonFingerprint(const CC *cond) {
-    unsigned char *out = calloc(1, 32);
-    //fprintf(stderr,"anon fingerprint %p %p\n",out,cond->fingerprint);
+static void anonFingerprint(const CC *cond, uint8_t *out) {
     memcpy(out, cond->fingerprint, 32);
-    return out;
 }
 
 

--- a/src/cryptoconditions/src/cryptoconditions.c
+++ b/src/cryptoconditions/src/cryptoconditions.c
@@ -62,8 +62,8 @@ void appendUriSubtypes(uint32_t mask, unsigned char *buf) {
 
 
 char *cc_conditionUri(const CC *cond) {
-    unsigned char *fp = cond->type->fingerprint(cond);
-    if (!fp) return NULL;
+    unsigned char *fp = calloc(1, 32);
+    cond->type->fingerprint(cond, fp);
 
     unsigned char *encoded = base64_encode(fp, 32);
 
@@ -115,9 +115,8 @@ uint32_t fromAsnSubtypes(const ConditionTypes_t types) {
 
 size_t cc_conditionBinary(const CC *cond, unsigned char *buf) {
     Condition_t *asn = calloc(1, sizeof(Condition_t));
-    bool r = asnCondition(cond, asn);
+    asnCondition(cond, asn);
     size_t out = 0;
-    if (!r) goto end;
     asn_enc_rval_t rc = der_encode_to_buffer(&asn_DEF_Condition, asn, buf, 1000);
     if (rc.encoded == -1) goto end;
     out = rc.encoded;
@@ -139,7 +138,7 @@ size_t cc_fulfillmentBinary(const CC *cond, unsigned char *buf, size_t length) {
 }
 
 
-bool asnCondition(const CC *cond, Condition_t *asn) {
+void asnCondition(const CC *cond, Condition_t *asn) {
     asn->present = cc_isAnon(cond) ? cond->conditionType->asnType : cond->type->asnType;
     
     // This may look a little weird - we dont have a reference here to the correct
@@ -148,13 +147,10 @@ bool asnCondition(const CC *cond, Condition_t *asn) {
 
     CompoundSha256Condition_t *choice = &asn->choice.thresholdSha256;
     choice->cost = cc_getCost(cond);
-    choice->fingerprint.buf = cond->type->fingerprint(cond);
-    if (choice->fingerprint.buf == 0) {
-        return 0;
-    }
     choice->fingerprint.size = 32;
+    choice->fingerprint.buf = calloc(1, 32);
+    cond->type->fingerprint(cond, choice->fingerprint.buf);
     choice->subtypes = asnSubtypes(cond->type->getSubtypes(cond));
-    return 1;
 }
 
 

--- a/src/cryptoconditions/src/ed25519.c
+++ b/src/cryptoconditions/src/ed25519.c
@@ -25,11 +25,10 @@
 struct CCType CC_Ed25519Type;
 
 
-static unsigned char *ed25519Fingerprint(const CC *cond) {
+static void ed25519Fingerprint(const CC *cond, uint8_t *out) {
     Ed25519FingerprintContents_t *fp = calloc(1, sizeof(Ed25519FingerprintContents_t));
-    //fprintf(stderr,"ed25519 fingerprint %p %p\n",fp,cond->publicKey);
     OCTET_STRING_fromBuf(&fp->publicKey, cond->publicKey, 32);
-    return hashFingerprintContents(&asn_DEF_Ed25519FingerprintContents, fp);
+    hashFingerprintContents(&asn_DEF_Ed25519FingerprintContents, fp, out);
 }
 
 

--- a/src/cryptoconditions/src/eval.c
+++ b/src/cryptoconditions/src/eval.c
@@ -25,11 +25,8 @@
 struct CCType CC_EvalType;
 
 
-static unsigned char *evalFingerprint(const CC *cond) {
-    unsigned char *hash = calloc(1, 32);
-    //fprintf(stderr,"evalfingerprint %p %p\n",hash,cond->code);
-    sha256(cond->code, cond->codeLength, hash);
-    return hash;
+static void evalFingerprint(const CC *cond, uint8_t *out) {
+    sha256(cond->code, cond->codeLength, out);
 }
 
 
@@ -105,7 +102,7 @@ static uint32_t evalSubtypes(const CC *cond) {
  */
 int jsonVerifyEval(CC *cond, void *context) {
     if (cond->codeLength == 5 && 0 == memcmp(cond->code, "TEST", 4)) {
-        return cond->code[5];
+        return cond->code[4];
     }
     fprintf(stderr, "Cannot verify eval; user function unknown\n");
     return 0;

--- a/src/cryptoconditions/src/include/secp256k1/src/ecmult_const.h
+++ b/src/cryptoconditions/src/include/secp256k1/src/ecmult_const.h
@@ -36,4 +36,4 @@ static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, cons
 
 
 #endif
-
+#endif

--- a/src/cryptoconditions/src/internal.h
+++ b/src/cryptoconditions/src/internal.h
@@ -39,7 +39,7 @@ typedef struct CCType {
     char name[100];
     Condition_PR asnType;
     int (*visitChildren)(CC *cond, CCVisitor visitor);
-    unsigned char *(*fingerprint)(const CC *cond);
+    void (*fingerprint)(const CC *cond, uint8_t *fp);
     unsigned long (*getCost)(const CC *cond);
     uint32_t (*getSubtypes)(const  CC *cond);
     CC *(*fromJSON)(const cJSON *params, char *err);
@@ -63,7 +63,7 @@ extern int CCTypeRegistryLength;
  */
 uint32_t fromAsnSubtypes(ConditionTypes_t types);
 CC *mkAnon(const Condition_t *asnCond);
-bool asnCondition(const CC *cond, Condition_t *asn);
+void asnCondition(const CC *cond, Condition_t *asn);
 Condition_t *asnConditionNew(const CC *cond);
 Fulfillment_t *asnFulfillmentNew(const CC *cond);
 struct CC *fulfillmentToCC(Fulfillment_t *ffill);
@@ -75,7 +75,7 @@ struct CCType *getTypeByAsnEnum(Condition_PR present);
  */
 unsigned char *base64_encode(const unsigned char *data, size_t input_length);
 unsigned char *base64_decode(const unsigned char *data_, size_t *output_length);
-unsigned char *hashFingerprintContents(asn_TYPE_descriptor_t *asnType, void *fp);
+void hashFingerprintContents(asn_TYPE_descriptor_t *asnType, void *fp, uint8_t* out);
 void dumpStr(unsigned char *str, size_t len);
 int checkString(const cJSON *value, char *key, char *err);
 int checkDecodeBase64(const cJSON *value, char *key, char *err, unsigned char **data, size_t *size);

--- a/src/cryptoconditions/src/prefix.c
+++ b/src/cryptoconditions/src/prefix.c
@@ -37,13 +37,12 @@ static int prefixVisitChildren(CC *cond, CCVisitor visitor) {
 }
 
 
-static unsigned char *prefixFingerprint(const CC *cond) {
+static void prefixFingerprint(const CC *cond, uint8_t *out) {
     PrefixFingerprintContents_t *fp = calloc(1, sizeof(PrefixFingerprintContents_t));
-    //fprintf(stderr,"prefixfinger %p %p\n",fp,cond->prefix);
-    asnCondition(cond->subcondition, &fp->subcondition); // TODO: check asnCondition for safety
+    asnCondition(cond->subcondition, &fp->subcondition);
     fp->maxMessageLength = cond->maxMessageLength;
     OCTET_STRING_fromBuf(&fp->prefix, cond->prefix, cond->prefixLength);
-    return hashFingerprintContents(&asn_DEF_PrefixFingerprintContents, fp);
+    hashFingerprintContents(&asn_DEF_PrefixFingerprintContents, fp, out);
 }
 
 

--- a/src/cryptoconditions/src/preimage.c
+++ b/src/cryptoconditions/src/preimage.c
@@ -44,11 +44,8 @@ static unsigned long preimageCost(const CC *cond) {
 }
 
 
-static unsigned char *preimageFingerprint(const CC *cond) {
-    unsigned char *hash = calloc(1, 32);
-    //fprintf(stderr,"preimage %p %p\n",hash,cond->preimage);
-    sha256(cond->preimage, cond->preimageLength, hash);
-    return hash;
+static void preimageFingerprint(const CC *cond, uint8_t *out) {
+    sha256(cond->preimage, cond->preimageLength, out);
 }
 
 

--- a/src/cryptoconditions/src/secp256k1.c
+++ b/src/cryptoconditions/src/secp256k1.c
@@ -88,11 +88,10 @@ void initVerify() {
 }
 
 
-static unsigned char *secp256k1Fingerprint(const CC *cond) {
+static void secp256k1Fingerprint(const CC *cond, uint8_t *out) {
     Secp256k1FingerprintContents_t *fp = calloc(1, sizeof(Secp256k1FingerprintContents_t));
-    //fprintf(stderr,"secpfinger %p %p size %d vs %d\n",fp,cond->publicKey,(int32_t)sizeof(Secp256k1FingerprintContents_t),(int32_t)SECP256K1_PK_SIZE);
     OCTET_STRING_fromBuf(&fp->publicKey, cond->publicKey, SECP256K1_PK_SIZE);
-    return hashFingerprintContents(&asn_DEF_Secp256k1FingerprintContents, fp);
+    hashFingerprintContents(&asn_DEF_Secp256k1FingerprintContents, fp, out);
 }
 
 

--- a/src/cryptoconditions/src/threshold.c
+++ b/src/cryptoconditions/src/threshold.c
@@ -94,17 +94,15 @@ static int cmpConditionBin(const void *a, const void *b) {
 }
 
 
-static unsigned char *thresholdFingerprint(const CC *cond) {
-    /* Create fingerprint */
+static void thresholdFingerprint(const CC *cond, uint8_t *out) {
     ThresholdFingerprintContents_t *fp = calloc(1, sizeof(ThresholdFingerprintContents_t));
-    //fprintf(stderr,"thresholdfinger %p\n",fp);
     fp->threshold = cond->threshold;
     for (int i=0; i<cond->size; i++) {
         Condition_t *asnCond = asnConditionNew(cond->subconditions[i]);
         asn_set_add(&fp->subconditions2, asnCond);
     }
     qsort(fp->subconditions2.list.array, cond->size, sizeof(Condition_t*), cmpConditionBin);
-    return hashFingerprintContents(&asn_DEF_ThresholdFingerprintContents, fp);
+    hashFingerprintContents(&asn_DEF_ThresholdFingerprintContents, fp, out);
 }
 
 

--- a/src/cryptoconditions/src/utils.c
+++ b/src/cryptoconditions/src/utils.c
@@ -210,7 +210,7 @@ void jsonAddBase64(cJSON *params, char *key, unsigned char *bin, size_t size) {
 }
 
 
-unsigned char *hashFingerprintContents(asn_TYPE_descriptor_t *asnType, void *fp) {
+void hashFingerprintContents(asn_TYPE_descriptor_t *asnType, void *fp, uint8_t *out) {
     unsigned char buf[BUF_SIZE];
     asn_enc_rval_t rc = der_encode_to_buffer(asnType, fp, buf, BUF_SIZE);
     ASN_STRUCT_FREE(*asnType, fp);
@@ -218,9 +218,7 @@ unsigned char *hashFingerprintContents(asn_TYPE_descriptor_t *asnType, void *fp)
         fprintf(stderr, "Encoding fingerprint failed\n");
         return 0;
     }
-    unsigned char *hash = calloc(1,32);
-    sha256(buf, rc.encoded, hash);
-    return hash;
+    sha256(buf, rc.encoded, out);
 }
 
 


### PR DESCRIPTION
@Alrighttt @ca333 

To give some context, generating the fingerprint is an operation that should not fail. Previously, the `CCType.fingerprint` method was returning a (uint8_t*). This is ambiguous because it's not clear if it may ever return NULL. The fix, is to have it return `void`, and pass the pre-allocated buffer as an extra parameter. This way it gives no room for suspicion that it may fail.