### PR TITLE
cleanwallettransactions: fix typos in JSON output

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1190,8 +1190,8 @@ UniValue cleanwallettransactions(const UniValue& params, bool fHelp, const CPubK
 
     // build return JSON for stats.
     int remaining = pwalletMain->mapWallet.size();
-    ret.push_back(Pair("total_transactons", (int)txs));
-    ret.push_back(Pair("remaining_transactons", (int)remaining));
+    ret.push_back(Pair("total_transactions", (int)txs));
+    ret.push_back(Pair("remaining_transactions", (int)remaining));
     ret.push_back(Pair("removed_transactions", (int)(txs-remaining)));
     return  (ret);
 }


### PR DESCRIPTION
Note that in another PR, in cleanwallettransactions, I may add a call to backupwallet prior to deleting txes + a warning to explain. I don't know if it is better to add it inside cleanwallettransactions or add the call to backupwallet in each script (Labs, webworker01, ...) that is using cleanwallettransactions. To be safe, I'd prefer to add it into komodo's code of cleanwallettransactions.