### PR TITLE
Bug Fixes (cppcheck)

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -274,7 +274,7 @@ CBlockTemplate* CreateNewBlock(CPubKey _pk,const CScript& _scriptPubKeyIn, int32
         {
             // too fast or stuck, this addresses the too fast issue, while moving
             // forward as quickly as possible
-            for (int i; i < 100; i++)
+            for (int i=0; i < 100; i++)
             {
                 proposedTime = GetTime();
                 if (proposedTime == nMedianTimePast)

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -218,9 +218,9 @@ public:
 };
 
 struct CExtPubKey {
-    unsigned char nDepth;
+    unsigned char nDepth = 0;
     unsigned char vchFingerprint[4];
-    unsigned int nChild;
+    unsigned int nChild = 0;
     ChainCode chaincode;
     CPubKey pubkey;
 


### PR DESCRIPTION
- DecodeExtPubKey (key_io.cpp) can return a default-constructed CExtPubKey. Set default values to 0.
- Uninitialized int in miner.cpp
