### PR TITLE
Fixes for GitHub CI (MacOS mainly)

### DIFF
--- a/.github/workflows/komodo_linux_ci.yml
+++ b/.github/workflows/komodo_linux_ci.yml
@@ -21,7 +21,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update  # prevents repo404 errors on apt-remove below
-          sudo apt-get remove php5.6-fpm php7.0-fpm php7.1-fpm php7.2-fpm php7.3-fpm php7.3-common php7.4-fpm msodbcsql17 mysql-server*
+          sudo apt-get remove msodbcsql17 mysql-server*
           sudo apt-get update
           sudo ACCEPT_EULA=Y apt-get upgrade -y
           sudo apt-get install -q \

--- a/.github/workflows/komodo_mac_ci.yml
+++ b/.github/workflows/komodo_mac_ci.yml
@@ -27,6 +27,7 @@ jobs:
           brew install coreutils
           brew install wget
           brew install python3
+          brew install gmp
           pip3 install setuptools wheel slick-bitcoinrpc pytest wget
           ./zcutil/fetch-params.sh
 

--- a/.github/workflows/komodo_win_ci.yml
+++ b/.github/workflows/komodo_win_ci.yml
@@ -53,7 +53,7 @@ jobs:
                              cmake \
                              clang \
                              libsodium-dev \
-                             python-zmq \
+                             python3-zmq \
                              mingw-w64 -y
         curl https://sh.rustup.rs -sSf | sh -s -- -y
         source $HOME/.cargo/env

--- a/.github/workflows/komodo_win_ci.yml
+++ b/.github/workflows/komodo_win_ci.yml
@@ -20,7 +20,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         sudo apt-get update  # prevents repo404 errors on apt-remove below
-        sudo apt-get remove php5.6-fpm php7.0-fpm php7.1-fpm php7.2-fpm php7.3-fpm php7.3-common php7.4-fpm msodbcsql17
+        sudo apt-get remove msodbcsql17
         sudo ACCEPT_EULA=Y apt-get upgrade -y
         sudo apt-get update
         sudo apt-get install build-essential \

--- a/.github/workflows/komodod_cd.yml
+++ b/.github/workflows/komodod_cd.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install deps (Linux)
         run: |
           sudo apt-get update  # prevents repo404 errors on apt-remove below
-          sudo apt-get remove php5.6-fpm php7.0-fpm php7.1-fpm php7.2-fpm php7.3-fpm php7.3-common php7.4-fpm msodbcsql17 mysql-server*
+          sudo apt-get remove msodbcsql17 mysql-server*
           sudo apt-get update
           sudo ACCEPT_EULA=Y apt-get upgrade -y
           sudo apt-get install -q \
@@ -108,12 +108,10 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get update  # prevents repo404 errors on apt-remove below
-          sudo apt-get remove php5.6-fpm php7.0-fpm php7.1-fpm php7.2-fpm php7.3-fpm php7.3-common php7.4-fpm
           sudo apt-get update
           sudo apt-get upgrade -y
           sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool libncurses-dev unzip git python zlib1g-dev wget bsdmainutils automake libboost-all-dev libssl-dev libprotobuf-dev protobuf-compiler libqrencode-dev libdb++-dev ntp ntpdate nano software-properties-common curl libevent-dev libcurl4-gnutls-dev cmake clang libsodium-dev -y
-          sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python python-zmq zlib1g-dev wget libcurl4-gnutls-dev bsdmainutils automake curl cmake mingw-w64
+          sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python python3-zmq zlib1g-dev wget libcurl4-gnutls-dev bsdmainutils automake curl cmake mingw-w64
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source $HOME/.cargo/env
           rustup target add x86_64-pc-windows-gnu

--- a/configure.ac
+++ b/configure.ac
@@ -743,7 +743,7 @@ fi
 # platforms, so we use older autoconf detection mechanisms:
 if test x$TARGET_OS = xdarwin; then
 AC_CHECK_HEADER([gmp.h],,AC_MSG_ERROR(libgmp headers missing))
-AC_CHECK_LIB([gmp],[[__gmpn_sub_n]],GMP_LIBS=-lgmp, [AC_MSG_ERROR(libgmp missing)])
+# AC_CHECK_LIB([gmp],[[__gmpn_sub_n]],GMP_LIBS=-lgmp, [AC_MSG_ERROR(libgmp missing)])
 
 AC_CHECK_HEADER([gmpxx.h],,AC_MSG_ERROR(libgmpxx headers missing))
 AC_CHECK_LIB([gmpxx],[main],GMPXX_LIBS=-lgmpxx, [AC_MSG_ERROR(libgmpxx missing)])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,7 +41,6 @@ if TARGET_LINUX
 LIBBITCOIN_SERVER=libbitcoin_server.a -lcurl
 endif
 
-LIBBITCOIN_WALLET=libbitcoin_wallet.a
 LIBBITCOIN_COMMON=libbitcoin_common.a
 LIBBITCOIN_CLI=libbitcoin_cli.a
 LIBBITCOIN_UTIL=libbitcoin_util.a

--- a/src/cryptoconditions/configure.ac
+++ b/src/cryptoconditions/configure.ac
@@ -12,7 +12,6 @@ LT_INIT
 
 # Checks for programs.
 AC_PROG_CC
-AC_PROG_CC_STDC
 
 # Checks for libraries.
 

--- a/src/cryptoconditions/src/include/secp256k1/configure.ac
+++ b/src/cryptoconditions/src/include/secp256k1/configure.ac
@@ -25,9 +25,9 @@ fi
 
 AM_PROG_CC_C_O
 
-AC_PROG_CC_C89
-if test x"$ac_cv_prog_cc_c89" = x"no"; then
-  AC_MSG_ERROR([c89 compiler support required])
+AC_PROG_CC
+if test x"$ac_cv_prog_cc_c11" = x"no"; then
+  AC_MSG_ERROR([c2011 compiler support required])
 fi
 AM_PROG_AS
 
@@ -65,7 +65,7 @@ esac
 
 CFLAGS="$CFLAGS -W"
 
-warn_CFLAGS="-std=c89 -pedantic -Wall -Wextra -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -Wno-unused-function -Wno-long-long -Wno-overlength-strings"
+warn_CFLAGS="-pedantic -Wall -Wextra -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -Wno-unused-function -Wno-long-long -Wno-overlength-strings"
 saved_CFLAGS="$CFLAGS"
 CFLAGS="$CFLAGS $warn_CFLAGS"
 AC_MSG_CHECKING([if ${CC} supports ${warn_CFLAGS}])

--- a/src/secp256k1/configure.ac
+++ b/src/secp256k1/configure.ac
@@ -25,9 +25,9 @@ fi
 
 AM_PROG_CC_C_O
 
-AC_PROG_CC_C89
-if test x"$ac_cv_prog_cc_c89" = x"no"; then
-  AC_MSG_ERROR([c89 compiler support required])
+AC_PROG_CC
+if test x"$ac_cv_prog_cc_c11" = x"no"; then
+  AC_MSG_ERROR([c2011 compiler support required])
 fi
 AM_PROG_AS
 
@@ -65,7 +65,7 @@ esac
 
 CFLAGS="$CFLAGS -W"
 
-warn_CFLAGS="-std=c89 -pedantic -Wall -Wextra -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -Wno-unused-function -Wno-long-long -Wno-overlength-strings"
+warn_CFLAGS="-pedantic -Wall -Wextra -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -Wno-unused-function -Wno-long-long -Wno-overlength-strings"
 saved_CFLAGS="$CFLAGS"
 CFLAGS="$CFLAGS $warn_CFLAGS"
 AC_MSG_CHECKING([if ${CC} supports ${warn_CFLAGS}])

--- a/zcutil/build-mac-dtest.sh
+++ b/zcutil/build-mac-dtest.sh
@@ -52,7 +52,7 @@ cd $WD
 
 ./autogen.sh
 CPPFLAGS="-I$PREFIX/include -arch x86_64 -DTESTMODE" LDFLAGS="-L$PREFIX/lib -arch x86_64 -Wl,-no_pie" \
-CXXFLAGS='-arch x86_64 -I/usr/local/Cellar/gcc\@8/8.3.0/include/c++/8.3.0/ -I$PREFIX/include -fwrapv -fno-strict-aliasing -Wno-builtin-declaration-mismatch -Werror -g -Wl,-undefined -Wl,dynamic_lookup' \
+CXXFLAGS='-arch x86_64 -I/usr/local/Cellar/gcc\@8/8.3.0/include/c++/8.3.0/ -I$PREFIX/include -fwrapv -fno-strict-aliasing -Wno-builtin-declaration-mismatch -Werror -Wno-error=attributes -g -Wl,-undefined -Wl,dynamic_lookup' \
 ./configure --prefix="${PREFIX}" --with-gui=no "$HARDENING_ARG" "$LCOV_ARG"
 
 make "$@" V=1 NO_GTEST=1 STATIC=1

--- a/zcutil/build-mac.sh
+++ b/zcutil/build-mac.sh
@@ -59,7 +59,7 @@ cd $WD
 
 ./autogen.sh
 CPPFLAGS="-I$PREFIX/include -arch x86_64" LDFLAGS="-L$PREFIX/lib -arch x86_64 -Wl,-no_pie" \
-CXXFLAGS='-arch x86_64 -I/usr/local/Cellar/gcc\@8/8.3.0/include/c++/8.3.0/ -I$PREFIX/include -fwrapv -fno-strict-aliasing -Wno-builtin-declaration-mismatch -Werror -g -Wl,-undefined -Wl,dynamic_lookup' \
+CXXFLAGS='-arch x86_64 -I/usr/local/Cellar/gcc\@8/8.3.0/include/c++/8.3.0/ -I$PREFIX/include -fwrapv -fno-strict-aliasing -Wno-builtin-declaration-mismatch -Werror -Wno-error=attributes -g -Wl,-undefined -Wl,dynamic_lookup' \
 ./configure --prefix="${PREFIX}" --with-gui=no "$HARDENING_ARG" "$LCOV_ARG"
 
 make "$@" V=1 NO_GTEST=1 STATIC=1


### PR DESCRIPTION
- `.yml` files attempted `apt-get remove` of various PHP versions, which all fail. Removed PHP packages from apt-get remove.
- mac builds failed due to check in the gmp lib, removed check.
- dirent.h uses __unused. Added -Wno-error:attributes to CXXFLAGS on mac
- mac C headers use c++ style comments. Removed forcing compiler to c89 standard.

Outstanding questions:
- What is the purpose of the de-installation of PHP? Are such removals required?
- What is a good test of libgmp that can be used on all platforms supported?
- What version of the C compiler should we support? 2011? 2017?