### PR TITLE
ExtractDestination is disabled to have vsolutions size > 1

### DIFF
--- a/src/komodo-tx.cpp
+++ b/src/komodo-tx.cpp
@@ -200,6 +200,12 @@ int32_t komodo_nextheight()
     return(100000000);
 }
 
+// function stub to allow build komodo-tx
+bool komodo_is_vSolutionsFixActive()
+{
+    return true;
+}
+
 
 // Set default values of new CMutableTransaction based on consensus rules at given height.
 CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Params& consensusParams, int nHeight)

--- a/src/komodo_utils.h
+++ b/src/komodo_utils.h
@@ -2498,7 +2498,9 @@ void komodo_prefetch(FILE *fp)
     fseek(fp,fpos,SEEK_SET);
 }
 
-bool komodo_Is2021JuneHFActive()
+// check if block timestamp is more than S5 activation time
+// this function is to activate the ExtractDestination fix 
+bool komodo_is_vSolutionsFixActive()
 {
     return GetLatestTimestamp(komodo_currentheight()) > nS5Timestamp;
 }

--- a/src/komodo_utils.h
+++ b/src/komodo_utils.h
@@ -2497,3 +2497,8 @@ void komodo_prefetch(FILE *fp)
     }
     fseek(fp,fpos,SEEK_SET);
 }
+
+bool komodo_Is2021JuneHFActive()
+{
+    return GetLatestTimestamp(komodo_currentheight()) < JUNE2021_NNELECTION_HARDFORK;
+}

--- a/src/komodo_utils.h
+++ b/src/komodo_utils.h
@@ -2500,5 +2500,5 @@ void komodo_prefetch(FILE *fp)
 
 bool komodo_Is2021JuneHFActive()
 {
-    return GetLatestTimestamp(komodo_currentheight()) < JUNE2021_NNELECTION_HARDFORK;
+    return GetLatestTimestamp(komodo_currentheight()) < nS5Timestamp;
 }

--- a/src/komodo_utils.h
+++ b/src/komodo_utils.h
@@ -2500,5 +2500,5 @@ void komodo_prefetch(FILE *fp)
 
 bool komodo_Is2021JuneHFActive()
 {
-    return GetLatestTimestamp(komodo_currentheight()) < nS5Timestamp;
+    return GetLatestTimestamp(komodo_currentheight()) > nS5Timestamp;
 }

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -34,6 +34,8 @@ typedef vector<unsigned char> valtype;
 
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
 
+bool komodo_Is2021JuneHFActive(); // didn't want to bring komodo headers here, it's a special case to bypass bad code in Solver() and ExtractDestination() 
+
 COptCCParams::COptCCParams(std::vector<unsigned char> &vch)
 {
     CScript inScr = CScript(vch.begin(), vch.end());
@@ -244,14 +246,19 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::v
                 for (i=0; i<20; i++)
                     ptr[i] = hash20[i];
                 vSolutionsRet.push_back(hashBytes);
-                if (vParams.size())
+
+                if (!komodo_Is2021JuneHFActive()) 
                 {
-                    COptCCParams cp = COptCCParams(vParams[0]);
-                    if (cp.IsValid())
+                    // allow this code before the hardfork if anyone might accidentally try it
+                    if (vParams.size())
                     {
-                        for (auto k : cp.vKeys)
+                        COptCCParams cp = COptCCParams(vParams[0]);
+                        if (cp.IsValid())
                         {
-                            vSolutionsRet.push_back(std::vector<unsigned char>(k.begin(), k.end()));
+                            for (auto k : cp.vKeys)
+                            {
+                                vSolutionsRet.push_back(std::vector<unsigned char>(k.begin(), k.end()));  // we do not need opdrop pubkeys in vSolution as it breaks indexes
+                            }
                         }
                     }
                 }
@@ -385,7 +392,7 @@ bool ExtractDestination(const CScript& _scriptPubKey, CTxDestination& addressRet
 
     else if (IsCryptoConditionsEnabled() != 0 && whichType == TX_CRYPTOCONDITION)
     {
-        if (vSolutions.size() > 1)
+        if (vSolutions.size() > 1 && !komodo_Is2021JuneHFActive()) // allow this temporarily before the HF; actually this is incorrect to use opdrop's pubkey as the address
         {
             CPubKey pk = CPubKey((vSolutions[1]));
             addressRet = pk;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -34,7 +34,7 @@ typedef vector<unsigned char> valtype;
 
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
 
-bool komodo_Is2021JuneHFActive(); // didn't want to bring komodo headers here, it's a special case to bypass bad code in Solver() and ExtractDestination() 
+bool komodo_is_vSolutionsFixActive(); // didn't want to bring komodo headers here, it's a special case to bypass bad code in Solver() and ExtractDestination() 
 
 COptCCParams::COptCCParams(std::vector<unsigned char> &vch)
 {
@@ -247,7 +247,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::v
                     ptr[i] = hash20[i];
                 vSolutionsRet.push_back(hashBytes);
 
-                if (!komodo_Is2021JuneHFActive()) 
+                if (!komodo_is_vSolutionsFixActive()) 
                 {
                     // allow this code before the hardfork if anyone might accidentally try it
                     if (vParams.size())
@@ -392,7 +392,7 @@ bool ExtractDestination(const CScript& _scriptPubKey, CTxDestination& addressRet
 
     else if (IsCryptoConditionsEnabled() != 0 && whichType == TX_CRYPTOCONDITION)
     {
-        if (vSolutions.size() > 1 && !komodo_Is2021JuneHFActive()) // allow this temporarily before the HF; actually this is incorrect to use opdrop's pubkey as the address
+        if (vSolutions.size() > 1 && !komodo_is_vSolutionsFixActive()) // allow this temporarily before the HF; actually this is incorrect to use opdrop's pubkey as the address
         {
             CPubKey pk = CPubKey((vSolutions[1]));
             addressRet = pk;

--- a/src/wallet-utility.cpp
+++ b/src/wallet-utility.cpp
@@ -356,3 +356,9 @@ int main(int argc, char* argv[])
     else
         return -1;
 }
+
+// function stub to allow build wallet-utility
+bool komodo_is_vSolutionsFixActive()
+{
+    return true;
+}


### PR DESCRIPTION
disable vSolutions size > 1 after June2021 HF as it might break addressindex (this was mistakenly pulled from verus code)