### PR TITLE
Event Refactor Phase 1

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -482,6 +482,7 @@ libbitcoin_common_a_SOURCES = \
   key.cpp \
   key_io.cpp \
   keystore.cpp \
+  komodo_structs.cpp \
   netbase.cpp \
   metrics.cpp \
   primitives/block.cpp \

--- a/src/Makefile.ktest.include
+++ b/src/Makefile.ktest.include
@@ -14,7 +14,8 @@ komodo_test_SOURCES = \
 	test-komodo/test_sha256_crypto.cpp \
 	test-komodo/test_script_standard_tests.cpp \
 	test-komodo/test_addrman.cpp \
-	test-komodo/test_netbase_tests.cpp
+	test-komodo/test_netbase_tests.cpp \
+    test-komodo/test_events.cpp
 
 komodo_test_CPPFLAGS = $(komodod_CPPFLAGS)
 

--- a/src/komodo.h
+++ b/src/komodo.h
@@ -215,6 +215,15 @@ int32_t komodo_parsestatefile(struct komodo_state *sp,FILE *fp,char *symbol,char
     } else return(-1);
 }
 
+/****
+ * Read a section of memory
+ * @param dest the destination
+ * @param size the size to read
+ * @param filedata the memory
+ * @param fposp the position to read from
+ * @param datalen the size of filedata
+ * @returns the number of bytes read or -1 on error
+ */
 int32_t memread(void *dest,int32_t size,uint8_t *filedata,long *fposp,long datalen)
 {
     if ( *fposp+size <= datalen )
@@ -226,21 +235,43 @@ int32_t memread(void *dest,int32_t size,uint8_t *filedata,long *fposp,long datal
     return(-1);
 }
 
+/****
+ * Parse file to get komodo events
+ * @param sp the state (stores the events)
+ * @param filedata the data to parse
+ * @param fposp the file position
+ * @param datalen the length of filedata
+ * @param symbol the currency symbol
+ * @param dest
+ * @returns the record type parsed, or -1 on error
+ */
 int32_t komodo_parsestatefiledata(struct komodo_state *sp,uint8_t *filedata,long *fposp,long datalen,char *symbol,char *dest)
 {
     static int32_t errs;
-    int32_t func= -1,ht,notarized_height,MoMdepth,num,matched=0; uint256 MoM,notarized_hash,notarized_desttxid; uint8_t pubkeys[64][33]; long fpos = *fposp;
+    int32_t func= -1;
+    int32_t ht; // height
+    int32_t notarized_height;
+    int32_t MoMdepth;
+    int32_t num;
+    int32_t matched=0; 
+    uint256 MoM;
+    uint256 notarized_hash;
+    uint256 notarized_desttxid; 
+    uint8_t pubkeys[64][33]; 
+    long fpos = *fposp;
+
     if ( fpos < datalen )
     {
         func = filedata[fpos++];
         if ( ASSETCHAINS_SYMBOL[0] == 0 && strcmp(symbol,"KMD") == 0 )
             matched = 1;
-        else matched = (strcmp(symbol,ASSETCHAINS_SYMBOL) == 0);
-        if ( memread(&ht,sizeof(ht),filedata,&fpos,datalen) != sizeof(ht) )
+        else 
+            matched = (strcmp(symbol,ASSETCHAINS_SYMBOL) == 0);
+        if ( memread(&ht,sizeof(ht),filedata,&fpos,datalen) != sizeof(ht) ) // get height
             errs++;
-        if ( func == 'P' )
+        if ( func == 'P' ) // pubkey record
         {
-            if ( (num= filedata[fpos++]) <= 64 )
+            if ( (num= filedata[fpos++]) <= 64 ) // number of keys in this record
             {
                 if ( memread(pubkeys,33*num,filedata,&fpos,datalen) != 33*num )
                     errs++;

--- a/src/komodo_bitcoind.h
+++ b/src/komodo_bitcoind.h
@@ -886,7 +886,7 @@ int32_t komodo_block2pubkey33(uint8_t *pubkey33,CBlock *block)
     if ( block->vtx[0].vout.size() > 0 )
     {
         txnouttype whichType;
-        vector<vector<unsigned char>> vch = vector<vector<unsigned char>>();
+        std::vector<std::vector<unsigned char>> vch = std::vector<std::vector<unsigned char>>();
         if (Solver(block->vtx[0].vout[0].scriptPubKey, whichType, vch) && whichType == TX_PUBKEY)
         {
             CPubKey pubKey(vch[0]);
@@ -2663,7 +2663,7 @@ int32_t komodo_staked(CMutableTransaction &txNew,uint32_t nBits,uint32_t *blockt
 {
     static struct komodo_staking *array; static int32_t numkp,maxkp; static uint32_t lasttime;
     int32_t PoSperc = 0, newStakerActive; 
-    set<CBitcoinAddress> setAddress; struct komodo_staking *kp; int32_t winners,segid,minage,nHeight,counter=0,i,m,siglen=0,nMinDepth = 1,nMaxDepth = 99999999; vector<COutput> vecOutputs; uint32_t block_from_future_rejecttime,besttime,eligible,earliest = 0; CScript best_scriptPubKey; arith_uint256 mindiff,ratio,bnTarget,tmpTarget; CBlockIndex *tipindex,*pindex; CTxDestination address; bool fNegative,fOverflow; uint8_t hashbuf[256]; CTransaction tx; uint256 hashBlock;
+    std::set<CBitcoinAddress> setAddress; struct komodo_staking *kp; int32_t winners,segid,minage,nHeight,counter=0,i,m,siglen=0,nMinDepth = 1,nMaxDepth = 99999999; std::vector<COutput> vecOutputs; uint32_t block_from_future_rejecttime,besttime,eligible,earliest = 0; CScript best_scriptPubKey; arith_uint256 mindiff,ratio,bnTarget,tmpTarget; CBlockIndex *tipindex,*pindex; CTxDestination address; bool fNegative,fOverflow; uint8_t hashbuf[256]; CTransaction tx; uint256 hashBlock;
     uint64_t cbPerc = *utxovaluep, tocoinbase = 0;
     if (!EnsureWalletIsAvailable(0))
         return 0;

--- a/src/komodo_events.h
+++ b/src/komodo_events.h
@@ -63,6 +63,14 @@ void komodo_eventadd_notarized(struct komodo_state *sp,char *symbol,int32_t heig
     }
 }
 
+/****
+ * Add a pubkey event to state
+ * @param sp the state
+ * @param symbol the symbol
+ * @param height
+ * @param num
+ * @param pubkeys
+ */
 void komodo_eventadd_pubkeys(struct komodo_state *sp,char *symbol,int32_t height,uint8_t num,uint8_t pubkeys[64][33])
 {
     struct komodo_event_pubkeys P;

--- a/src/komodo_events.h
+++ b/src/komodo_events.h
@@ -22,7 +22,7 @@ struct komodo_event *komodo_eventadd(struct komodo_state *sp,int32_t height,char
     struct komodo_event *ep=0; uint16_t len = (uint16_t)(sizeof(*ep) + datalen);
     if ( sp != 0 && ASSETCHAINS_SYMBOL[0] != 0 )
     {
-        portable_mutex_lock(&komodo_mutex);
+        std::lock_guard<std::mutex> lock(komodo_mutex);
         ep = (struct komodo_event *)calloc(1,len);
         ep->len = len;
         ep->height = height;
@@ -32,7 +32,6 @@ struct komodo_event *komodo_eventadd(struct komodo_state *sp,int32_t height,char
             memcpy(ep->space,data,datalen);
         sp->Komodo_events = (struct komodo_event **)realloc(sp->Komodo_events,(1 + sp->Komodo_numevents) * sizeof(*sp->Komodo_events));
         sp->Komodo_events[sp->Komodo_numevents++] = ep;
-        portable_mutex_unlock(&komodo_mutex);
     }
     return(ep);
 }

--- a/src/komodo_gateway.h
+++ b/src/komodo_gateway.h
@@ -1259,6 +1259,14 @@ void komodo_stateind_set(struct komodo_state *sp,uint32_t *inds,int32_t n,uint8_
     else if ( func == 'R' ) // opreturn:*/
 }
 
+/****
+ * Load file contents into buffer
+ * @param fname the filename
+ * @param bufp the buffer that will contain the file contents
+ * @param lenp the length of the file
+ * @param allocsizep the buffer size allocated
+ * @returns the file contents
+ */
 void *OS_loadfile(char *fname,uint8_t **bufp,long *lenp,long *allocsizep)
 {
     FILE *fp;
@@ -1297,9 +1305,17 @@ void *OS_loadfile(char *fname,uint8_t **bufp,long *lenp,long *allocsizep)
     return(buf);
 }
 
+/***
+ * Get file contents
+ * @param allocsizep the size allocated for the file contents (NOTE: this will probably be 64 bytes larger than the file size)
+ * @param fname the file name
+ * @returns the data from the file
+ */
 uint8_t *OS_fileptr(long *allocsizep,char *fname)
 {
-    long filesize = 0; uint8_t *buf = 0; void *retptr;
+    long filesize = 0; // the size of the file 
+    uint8_t *buf = 0; // a pointer to the buffer
+    void *retptr; // the return pointer (points to buf)
     *allocsizep = 0;
     retptr = OS_loadfile(fname,&buf,&filesize,allocsizep);
     return((uint8_t *)retptr);
@@ -1369,6 +1385,14 @@ long komodo_indfile_update(FILE *indfp,uint32_t *prevpos100p,long lastfpos,long 
     return(newfpos);
 }
 
+/***
+ * Initialize state from the filesystem
+ * @param sp the state to initialize
+ * @param fname the filename
+ * @param symbol
+ * @param dest
+ * @returns -1 on error, 1 on success
+ */
 int32_t komodo_faststateinit(struct komodo_state *sp,char *fname,char *symbol,char *dest)
 {
     FILE *indfp; char indfname[1024]; uint8_t *filedata; long validated=-1,datalen,fpos,lastfpos; uint32_t tmp,prevpos100,indcounter,starttime; int32_t func,finished = 0;

--- a/src/komodo_globals.h
+++ b/src/komodo_globals.h
@@ -13,6 +13,7 @@
  *                                                                            *
  ******************************************************************************/
 #pragma once
+#include <mutex>
 #include "komodo_defs.h"
 
 void komodo_prefetch(FILE *fp);

--- a/src/komodo_globals.h
+++ b/src/komodo_globals.h
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.            *
  *                                                                            *
  ******************************************************************************/
-
+#pragma once
 #include "komodo_defs.h"
 
 void komodo_prefetch(FILE *fp);
@@ -31,7 +31,8 @@ uint64_t komodo_maxallowed(int32_t baseid);
 int32_t komodo_bannedset(int32_t *indallvoutsp,uint256 *array,int32_t max);
 int32_t komodo_checkvout(int32_t vout,int32_t k,int32_t indallvouts);
 
-pthread_mutex_t komodo_mutex,staked_mutex;
+std::mutex komodo_mutex;
+pthread_mutex_t staked_mutex;
 
 #define KOMODO_ELECTION_GAP 2000    //((ASSETCHAINS_SYMBOL[0] == 0) ? 2000 : 100)
 #define KOMODO_ASSETCHAIN_MAXLEN 65

--- a/src/komodo_notary.h
+++ b/src/komodo_notary.h
@@ -149,19 +149,20 @@ int32_t komodo_notaries(uint8_t pubkeys[64][33],int32_t height,uint32_t timestam
         komodo_init(height);
         //printf("Pubkeys.%p htind.%d vs max.%d\n",Pubkeys,htind,KOMODO_MAXBLOCKS / KOMODO_ELECTION_GAP);
     }
-    pthread_mutex_lock(&komodo_mutex);
-    n = Pubkeys[htind].numnotaries;
-    if ( 0 && ASSETCHAINS_SYMBOL[0] != 0 )
-        fprintf(stderr,"%s height.%d t.%u genesis.%d\n",ASSETCHAINS_SYMBOL,height,timestamp,n);
-    HASH_ITER(hh,Pubkeys[htind].Notaries,kp,tmp)
     {
-        if ( kp->notaryid < n )
+        std::lock_guard<std::mutex> lock(komodo_mutex);
+        n = Pubkeys[htind].numnotaries;
+        if ( 0 && ASSETCHAINS_SYMBOL[0] != 0 )
+            fprintf(stderr,"%s height.%d t.%u genesis.%d\n",ASSETCHAINS_SYMBOL,height,timestamp,n);
+        HASH_ITER(hh,Pubkeys[htind].Notaries,kp,tmp)
         {
-            mask |= (1LL << kp->notaryid);
-            memcpy(pubkeys[kp->notaryid],kp->pubkey,33);
-        } else printf("illegal notaryid.%d vs n.%d\n",kp->notaryid,n);
+            if ( kp->notaryid < n )
+            {
+                mask |= (1LL << kp->notaryid);
+                memcpy(pubkeys[kp->notaryid],kp->pubkey,33);
+            } else printf("illegal notaryid.%d vs n.%d\n",kp->notaryid,n);
+        }
     }
-    pthread_mutex_unlock(&komodo_mutex);
     if ( (n < 64 && mask == ((1LL << n)-1)) || (n == 64 && mask == 0xffffffffffffffffLL) )
         return(n);
     printf("error retrieving notaries ht.%d got mask.%llx for n.%d\n",height,(long long)mask,n);
@@ -213,7 +214,7 @@ void komodo_notarysinit(int32_t origheight,uint8_t pubkeys[64][33],int32_t num)
             htind = (KOMODO_MAXBLOCKS / KOMODO_ELECTION_GAP) - 1;
         //printf("htind.%d activation %d from %d vs %d | hwmheight.%d %s\n",htind,height,origheight,(((origheight+KOMODO_ELECTION_GAP/2)/KOMODO_ELECTION_GAP)+1)*KOMODO_ELECTION_GAP,hwmheight,ASSETCHAINS_SYMBOL);
     } else htind = 0;
-    pthread_mutex_lock(&komodo_mutex);
+    std::lock_guard<std::mutex> lock(komodo_mutex);
     for (k=0; k<num; k++)
     {
         kp = (struct knotary_entry *)calloc(1,sizeof(*kp));
@@ -238,7 +239,6 @@ void komodo_notarysinit(int32_t origheight,uint8_t pubkeys[64][33],int32_t num)
         Pubkeys[i] = N;
         Pubkeys[i].height = i * KOMODO_ELECTION_GAP;
     }
-    pthread_mutex_unlock(&komodo_mutex);
     if ( origheight > hwmheight )
         hwmheight = origheight;
 }
@@ -268,9 +268,10 @@ int32_t komodo_chosennotary(int32_t *notaryidp,int32_t height,uint8_t *pubkey33,
     htind = height / KOMODO_ELECTION_GAP;
     if ( htind >= KOMODO_MAXBLOCKS / KOMODO_ELECTION_GAP )
         htind = (KOMODO_MAXBLOCKS / KOMODO_ELECTION_GAP) - 1;
-    pthread_mutex_lock(&komodo_mutex);
-    HASH_FIND(hh,Pubkeys[htind].Notaries,pubkey33,33,kp);
-    pthread_mutex_unlock(&komodo_mutex);
+    {
+        std::lock_guard<std::mutex> lock(komodo_mutex);
+        HASH_FIND(hh,Pubkeys[htind].Notaries,pubkey33,33,kp);
+    }
     if ( kp != 0 )
     {
         if ( (numnotaries= Pubkeys[htind].numnotaries) > 0 )
@@ -469,7 +470,7 @@ void komodo_notarized_update(struct komodo_state *sp,int32_t nHeight,int32_t not
     }
     if ( 0 && ASSETCHAINS_SYMBOL[0] != 0 )
         fprintf(stderr,"[%s] komodo_notarized_update nHeight.%d notarized_height.%d\n",ASSETCHAINS_SYMBOL,nHeight,notarized_height);
-    portable_mutex_lock(&komodo_mutex);
+    std::lock_guard<std::mutex> lock(komodo_mutex);
     sp->NPOINTS = (struct notarized_checkpoint *)realloc(sp->NPOINTS,(sp->NUM_NPOINTS+1) * sizeof(*sp->NPOINTS));
     np = &sp->NPOINTS[sp->NUM_NPOINTS++];
     memset(np,0,sizeof(*np));
@@ -479,7 +480,6 @@ void komodo_notarized_update(struct komodo_state *sp,int32_t nHeight,int32_t not
     sp->NOTARIZED_DESTTXID = np->notarized_desttxid = notarized_desttxid;
     sp->MoM = np->MoM = MoM;
     sp->MoMdepth = np->MoMdepth = MoMdepth;
-    portable_mutex_unlock(&komodo_mutex);
 }
 
 void komodo_init(int32_t height)
@@ -490,7 +490,6 @@ void komodo_init(int32_t height)
     memset(&zero,0,sizeof(zero));
     if ( didinit == 0 )
     {
-        pthread_mutex_init(&komodo_mutex,NULL);
         decode_hex(NOTARY_PUBKEY33,33,(char *)NOTARY_PUBKEY.c_str());
         if ( height >= 0 )
         {

--- a/src/komodo_structs.cpp
+++ b/src/komodo_structs.cpp
@@ -1,4 +1,5 @@
 #include <komodo_structs.h>
+#include <mutex>
 
 extern std::mutex komodo_mutex;
 

--- a/src/komodo_structs.cpp
+++ b/src/komodo_structs.cpp
@@ -3,6 +3,73 @@
 extern std::mutex komodo_mutex;
 
 
+/***
+ * komodo_state
+ */
+
+bool komodo_state::add_event(const std::string& symbol, const uint32_t height, std::shared_ptr<komodo::event> in)
+{
+    if (ASSETCHAINS_SYMBOL[0] != 0)
+    {
+        std::lock_guard<std::mutex> lock(komodo_mutex);
+        events.push_back( in );
+        return true;
+    }
+    return false;
+}
+
+namespace komodo {
+
+/***
+ * Helps serialize integrals
+ */
+template<class T>
+class serializable
+{
+public:
+    serializable(const T& in) : value(in) {}
+    T value;
+};
+
+std::ostream& operator<<(std::ostream& os, serializable<int32_t> in)
+{
+    os  << (uint8_t) (in.value & 0x000000ff)
+        << (uint8_t) ((in.value & 0x0000ff00) >> 8)
+        << (uint8_t) ((in.value & 0x00ff0000) >> 16)
+        << (uint8_t) ((in.value & 0xff000000) >> 24);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, serializable<uint16_t> in)
+{
+    os  << (uint8_t)  (in.value & 0x00ff)
+        << (uint8_t) ((in.value & 0xff00) >> 8);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, serializable<uint256> in)
+{
+    in.value.Serialize(os);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, serializable<uint64_t> in)
+{
+    os  << (uint8_t)  (in.value & 0x00000000000000ff)
+        << (uint8_t) ((in.value & 0x000000000000ff00) >> 8)
+        << (uint8_t) ((in.value & 0x0000000000ff0000) >> 16)
+        << (uint8_t) ((in.value & 0x00000000ff000000) >> 24)
+        << (uint8_t) ((in.value & 0x000000ff00000000) >> 32)
+        << (uint8_t) ((in.value & 0x0000ff0000000000) >> 40)
+        << (uint8_t) ((in.value & 0x00ff000000000000) >> 48)
+        << (uint8_t) ((in.value & 0xff00000000000000) >> 56);
+    return os;
+}
+
+/***
+ * Read a chunk of memory
+ */
+
 template<class T>
 std::size_t mem_read(T& dest, uint8_t *filedata, long &fpos, long datalen)
 {
@@ -13,6 +80,17 @@ std::size_t mem_read(T& dest, uint8_t *filedata, long &fpos, long datalen)
         return sizeof(T);
     }
     throw parse_error("Invalid size: " + std::to_string(sizeof(T)) );
+}
+
+std::size_t mem_readn(void* dest, size_t num_bytes, uint8_t *filedata, long &fpos, long datalen)
+{
+    if (fpos + num_bytes <= datalen)
+    {
+        memcpy(dest, &filedata[fpos], num_bytes );
+        fpos += num_bytes;
+        return num_bytes;
+    }
+    throw parse_error("Invalid size: " + std::to_string(num_bytes) );
 }
 
 template<class T, std::size_t N>
@@ -28,6 +106,9 @@ std::size_t mem_read(T(&dest)[N], uint8_t *filedata, long& fpos, long datalen)
     throw parse_error("Invalid size: "  + std::to_string( sz ) );
 }
 
+/****
+ * Read a size that is less than the array length
+ */
 template<class T, std::size_t N>
 std::size_t mem_nread(T(&dest)[N], size_t num_elements, uint8_t *filedata, long& fpos, long datalen)
 {
@@ -41,15 +122,50 @@ std::size_t mem_nread(T(&dest)[N], size_t num_elements, uint8_t *filedata, long&
     throw parse_error("Invalid size: " + std::to_string(sz));
 }
 
-bool komodo_state::add_event(const std::string& symbol, const uint32_t height, std::shared_ptr<event> in)
+
+/****
+ * This serializes the 5 byte header of an event
+ * @param os the stream
+ * @param in the event
+ * @returns the stream
+ */
+std::ostream& operator<<(std::ostream& os, const event& in)
 {
-    if (ASSETCHAINS_SYMBOL[0] != 0)
+    switch (in.type)
     {
-        std::lock_guard<std::mutex> lock(komodo_mutex);
-        events.push_back( in );
-        return true;
+        case(EVENT_PUBKEYS):
+            os << "P";
+            break;
+        case(EVENT_NOTARIZED):
+        {
+            event_notarized* tmp = dynamic_cast<event_notarized*>(const_cast<event*>(&in));
+            if (tmp->MoMdepth == 0)
+                os << "N";
+            else
+                os << "M";
+            break;
+        }
+        case(EVENT_U):
+            os << "U";
+            break;
+        case(EVENT_KMDHEIGHT):
+        {
+            event_kmdheight* tmp = dynamic_cast<event_kmdheight*>(const_cast<event*>(&in));
+            if (tmp->timestamp == 0)
+                os << "K";
+            else
+                os << "T";
+            break;
+        }
+        case(EVENT_OPRETURN):
+            os << "R";
+            break;
+        case(EVENT_PRICEFEED):
+            os << "V";
+            break;
     }
-    return false;
+    os << serializable<int32_t>(in.height);
+    return os;
 }
 
 /***
@@ -58,7 +174,7 @@ bool komodo_state::add_event(const std::string& symbol, const uint32_t height, s
  * @param pos the starting position (will advance)
  * @param data_len full length of data
  */
-komodo_event_pubkeys::komodo_event_pubkeys(uint8_t* data, long& pos, long data_len, int32_t height) : event(KOMODO_EVENT_PUBKEYS, height)
+event_pubkeys::event_pubkeys(uint8_t* data, long& pos, long data_len, int32_t height) : event(EVENT_PUBKEYS, height)
 {
     num = data[pos++];
     if (num > 64)
@@ -66,10 +182,122 @@ komodo_event_pubkeys::komodo_event_pubkeys(uint8_t* data, long& pos, long data_l
     mem_nread(pubkeys, num, data, pos, data_len);
 }
 
-std::ostream& operator<<(std::ostream& os, const komodo_event_pubkeys& in)
+std::ostream& operator<<(std::ostream& os, const event_pubkeys& in)
 {
+    const event& e = dynamic_cast<const event&>(in);
+    os << e;
     os << in.num;
-    for(uint8_t i = 0; i < in.num; ++i)
+    for(uint8_t i = 0; i < in.num-1; ++i)
         os << in.pubkeys[i];
     return os;
 }
+
+event_notarized::event_notarized(uint8_t *data, long &pos, long data_len, int32_t height, bool includeMoM) : event(EVENT_NOTARIZED, height)
+{
+    mem_read(this->notarizedheight, data, pos, data_len);
+    mem_read(this->blockhash, data, pos, data_len);
+    mem_read(this->desttxid, data, pos, data_len);
+    if (includeMoM)
+    {
+        mem_read(this->MoM, data, pos, data_len);
+        mem_read(this->MoMdepth, data, pos, data_len);
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, const event_notarized& in)
+{
+    const event& e = dynamic_cast<const event&>(in);
+    os << e;
+    os << serializable<int32_t>(in.notarizedheight);
+    os << serializable<uint256>(in.blockhash);
+    os << serializable<uint256>(in.desttxid);
+    if (in.MoMdepth > 0)
+    {
+        os << serializable<uint256>(in.MoM);
+        os << serializable<int32_t>(in.MoMdepth);
+    }
+    return os;
+}
+
+event_u::event_u(uint8_t *data, long &pos, long data_len, int32_t height) : event(EVENT_U, height)
+{
+    mem_read(this->n, data, pos, data_len);
+    mem_read(this->nid, data, pos, data_len);
+    mem_read(this->mask, data, pos, data_len);
+    mem_read(this->hash, data, pos, data_len);
+}
+
+std::ostream& operator<<(std::ostream& os, const event_u& in)
+{
+    const event& e = dynamic_cast<const event&>(in);
+    os << e;
+    os << in.n << in.nid;
+    os.write((const char*)in.mask, 8);
+    os.write((const char*)in.hash, 32);
+    return os;
+}
+
+event_kmdheight::event_kmdheight(uint8_t* data, long &pos, long data_len, int32_t height, bool includeTimestamp) : event(EVENT_KMDHEIGHT, height)
+{
+    mem_read(this->kheight, data, pos, data_len);
+    if (includeTimestamp)
+        mem_read(this->timestamp, data, pos, data_len);
+}
+
+std::ostream& operator<<(std::ostream& os, const event_kmdheight& in)
+{
+    const event& e = dynamic_cast<const event&>(in);
+    os << e << serializable<int32_t>(in.kheight);
+    if (in.timestamp > 0)
+        os << serializable<int32_t>(in.timestamp);
+    return os;
+}
+
+event_opreturn::event_opreturn(uint8_t *data, long &pos, long data_len, int32_t height) : event(EVENT_OPRETURN, height)
+{
+    mem_read(this->txid, data, pos, data_len);
+    mem_read(this->value, data, pos, data_len);
+    mem_read(this->vout, data, pos, data_len);
+    mem_read(this->oplen, data, pos, data_len);
+    this->opret = new uint8_t[this->oplen];
+    mem_readn(this->opret, this->oplen, data, pos, data_len);
+}
+
+event_opreturn::~event_opreturn()
+{
+    if (opret != nullptr)
+        delete[] opret;
+}
+
+std::ostream& operator<<(std::ostream& os, const event_opreturn& in)
+{
+    const event& e = dynamic_cast<const event&>(in);
+    os << e 
+        << serializable<uint256>(in.txid)
+        << serializable<uint64_t>(in.value)
+        << serializable<uint16_t>(in.vout)
+        << serializable<uint16_t>(in.oplen);
+    os.write( (const char*)in.opret, in.oplen);
+    return os;
+}
+
+event_pricefeed::event_pricefeed(uint8_t *data, long &pos, long data_len, int32_t height) : event(EVENT_PRICEFEED, height)
+{
+    mem_read(this->num, data, pos, data_len);
+    // we're only interested if there are 35 prices. 
+    // If there is any other amount, advance the pointer, but don't save it
+    if (this->num == 35)
+        mem_nread(this->prices, this->num, data, pos, data_len);
+    else
+        pos += num * sizeof(uint32_t);
+}
+
+std::ostream& operator<<(std::ostream& os, const event_pricefeed& in)
+{
+    const event& e = dynamic_cast<const event&>(in);
+    os << e << (uint8_t)in.num;
+    os.write((const char*)in.prices, in.num * sizeof(uint32_t));
+    return os;
+}
+
+} // namespace komodo

--- a/src/komodo_structs.cpp
+++ b/src/komodo_structs.cpp
@@ -1,0 +1,75 @@
+#include <komodo_structs.h>
+
+extern std::mutex komodo_mutex;
+
+
+template<class T>
+std::size_t mem_read(T& dest, uint8_t *filedata, long &fpos, long datalen)
+{
+    if (fpos + sizeof(T) <= datalen)
+    {
+        memcpy( &dest, &filedata[fpos], sizeof(T) );
+        fpos += sizeof(T);
+        return sizeof(T);
+    }
+    throw parse_error("Invalid size: " + std::to_string(sizeof(T)) );
+}
+
+template<class T, std::size_t N>
+std::size_t mem_read(T(&dest)[N], uint8_t *filedata, long& fpos, long datalen)
+{
+    std::size_t sz = sizeof(T) * N;
+    if (fpos + sz <= datalen)
+    {
+        memcpy( &dest, &filedata[fpos], sz );
+        fpos += sz;
+        return sz;
+    }
+    throw parse_error("Invalid size: "  + std::to_string( sz ) );
+}
+
+template<class T, std::size_t N>
+std::size_t mem_nread(T(&dest)[N], size_t num_elements, uint8_t *filedata, long& fpos, long datalen)
+{
+    std::size_t sz = sizeof(T) * num_elements;
+    if (fpos + sz <= datalen)
+    {
+        memcpy( &dest, &filedata[fpos], sz );
+        fpos += sz;
+        return sz;
+    }
+    throw parse_error("Invalid size: " + std::to_string(sz));
+}
+
+bool komodo_state::add_event(const std::string& symbol, const uint32_t height, std::shared_ptr<event> in)
+{
+    if (ASSETCHAINS_SYMBOL[0] != 0)
+    {
+        std::lock_guard<std::mutex> lock(komodo_mutex);
+        events.push_back( in );
+        return true;
+    }
+    return false;
+}
+
+/***
+ * ctor from data stream
+ * @param data the data stream
+ * @param pos the starting position (will advance)
+ * @param data_len full length of data
+ */
+komodo_event_pubkeys::komodo_event_pubkeys(uint8_t* data, long& pos, long data_len, int32_t height) : event(KOMODO_EVENT_PUBKEYS, height)
+{
+    num = data[pos++];
+    if (num > 64)
+        throw parse_error("Illegal number of keys: " + std::to_string(num));
+    mem_nread(pubkeys, num, data, pos, data_len);
+}
+
+std::ostream& operator<<(std::ostream& os, const komodo_event_pubkeys& in)
+{
+    os << in.num;
+    for(uint8_t i = 0; i < in.num; ++i)
+        os << in.pubkeys[i];
+    return os;
+}

--- a/src/komodo_structs.cpp
+++ b/src/komodo_structs.cpp
@@ -2,7 +2,6 @@
 
 extern std::mutex komodo_mutex;
 
-
 /***
  * komodo_state
  */

--- a/src/komodo_structs.h
+++ b/src/komodo_structs.h
@@ -91,12 +91,18 @@ enum komodo_event_type
     EVENT_PRICEFEED
 };
 
+/***
+ * Thrown by event constructors when it finds a problem with the input data
+ */
 class parse_error : public std::logic_error
 {
 public:
     parse_error(const std::string& in) : std::logic_error(in) {}
 };
 
+/***
+ * base class for events
+ */
 class event
 {
 public:
@@ -106,7 +112,6 @@ public:
     int32_t height;
 };
 std::ostream& operator<<(std::ostream& os, const event& in);
-
 
 struct event_notarized : public event
 {
@@ -236,7 +241,6 @@ struct komodo_state
     std::list<std::shared_ptr<komodo::event>> events;
     uint32_t RTbufs[64][3]; uint64_t RTmask;
     bool add_event(const std::string& symbol, const uint32_t height, std::shared_ptr<komodo::event> in);
-
 };
 
 #endif /* KOMODO_STRUCTS_H */

--- a/src/test-komodo/test_events.cpp
+++ b/src/test-komodo/test_events.cpp
@@ -459,6 +459,45 @@ TEST(TestEvents, komodo_faststateinit_test)
             komodo_event* ev1 = state->Komodo_events[7];
             ASSERT_EQ(ev1->height, 1);
             ASSERT_EQ(ev1->type, 'P');
+            // check that the new way is the same
+            ASSERT_EQ(state->events.size(), 14);
+            auto itr = state->events.begin();
+            std::advance(itr, 7);
+            {
+                ASSERT_EQ( (*itr)->height, 1);
+                ASSERT_EQ( (*itr)->type, komodo::komodo_event_type::EVENT_PUBKEYS);
+                itr++;
+            }
+            {
+                ASSERT_EQ( (*itr)->height, 1);
+                ASSERT_EQ( (*itr)->type, komodo::komodo_event_type::EVENT_NOTARIZED);
+                itr++;
+            }
+            {
+                ASSERT_EQ( (*itr)->height, 1);
+                ASSERT_EQ( (*itr)->type, komodo::komodo_event_type::EVENT_NOTARIZED);
+                itr++;
+            }
+            {
+                ASSERT_EQ( (*itr)->height, 1);
+                ASSERT_EQ( (*itr)->type, komodo::komodo_event_type::EVENT_KMDHEIGHT);
+                itr++;
+            }
+            {
+                ASSERT_EQ( (*itr)->height, 1);
+                ASSERT_EQ( (*itr)->type, komodo::komodo_event_type::EVENT_KMDHEIGHT);
+                itr++;
+            }
+            {
+                ASSERT_EQ( (*itr)->height, 1);
+                ASSERT_EQ( (*itr)->type, komodo::komodo_event_type::EVENT_OPRETURN);
+                itr++;
+            }
+            {
+                ASSERT_EQ( (*itr)->height, 1);
+                ASSERT_EQ( (*itr)->type, komodo::komodo_event_type::EVENT_PRICEFEED);
+                itr++;
+            }
         }
     } 
     catch(...)

--- a/src/test-komodo/test_events.cpp
+++ b/src/test-komodo/test_events.cpp
@@ -2,42 +2,365 @@
 #include <cstdio>
 #include <cstdlib>
 #include <boost/filesystem.hpp>
-//#define KOMODO_ZCASH
-//#include <komodo.h>
+#include <komodo_structs.h>
 
-struct komodo_state;
 int32_t komodo_faststateinit(struct komodo_state *sp,char *fname,char *symbol,char *dest);
 struct komodo_state *komodo_stateptrget(char *base);
+extern int32_t KOMODO_EXTERNAL_NOTARIES;
 
 namespace TestEvents {
 
-TEST(TestEvents, komodo_faststateinit_test)
+void write_p_record(std::FILE* fp)
 {
-    // create a binary file that should be readable by komodo
-    boost::filesystem::path temp = boost::filesystem::unique_path();
-    boost::filesystem::create_directories(temp);
-    const std::string temp_filename = temp.native() + "/kstate.tmp";
-    char full_filename[temp_filename.size()+1];
-    strcpy(full_filename, temp_filename.c_str());
-    std::FILE* fp = std::fopen(full_filename, "wb+");
-    ASSERT_NE(fp, nullptr);
     // a pubkey record with 2 keys
-    char data[1+4+1+(33*2)] = {'P', 1, 0, 0, 0, 2}; // public key record identifier with height of 1 plus number of keys plus keys themselves
+    char data[5+1+(33*2)] = {'P', 1, 0, 0, 0, 2}; // public key record identifier with height of 1 plus number of keys plus keys themselves
     memset(&data[6], 1, 33); // 1st key is all 1s
     memset(&data[39], 2, 33); // 2nd key is all 2s
     std::fwrite(data, sizeof(data), 1, fp);
-    std::fclose(fp);
-    // verify file still exists
-    ASSERT_TRUE(boost::filesystem::exists(full_filename));
-    // attempt to read the file
-    char symbol[] = "KMD";
-    komodo_state* state = komodo_stateptrget((char*)symbol);
-    ASSERT_NE(state, nullptr);
-    char* dest = nullptr;
-    // attempt to read the file
-    int32_t result = komodo_faststateinit( state, full_filename, symbol, dest);
-    // compare results
-    ASSERT_EQ(result, 1);
+}
+void write_n_record(std::FILE* fp)
+{
+    // a notarized record has
+    // 5 byte header 
+    // 4 bytes notarized_height
+    // 32 bytes notarized hash( blockhash)
+    // 32 bytes desttxid
+    char data[73] = {'N', 1, 0, 0, 0, 2, 0, 0, 0};
+    memset(&data[9], 1, 32); // notarized hash
+    memset(&data[41], 2, 32); // desttxid
+    std::fwrite(data, sizeof(data), 1, fp);
+}
+void write_m_record(std::FILE* fp)
+{
+    // a notarized M record has
+    // 5 byte header 
+    // 4 bytes notarized_height
+    // 32 bytes notarized hash( blockhash)
+    // 32 bytes desttxid
+    // 32 bytes MoM
+    // 4 bytes MoMdepth
+    char data[109] = {'M', 1, 0, 0, 0, 3, 0, 0, 0};
+    memset(&data[9], 1, 32); // notarized hash
+    memset(&data[41], 2, 32); // desttxid
+    memset(&data[73], 3, 32); // MoM
+    memset(&data[105], 4, 4); // MoMdepth
+    std::fwrite(data, sizeof(data), 1, fp);
+}
+void write_u_record(std::FILE* fp)
+{
+    // a U record has
+    // 5 byte header 
+    // 1 byte n and 1 byte nid
+    // 8 bytes mask
+    // 32 bytes hash
+    char data[47] = {'U', 1, 0, 0, 0, 'N', 'I'};
+    memset(&data[7], 1, 8); // mask
+    memset(&data[15], 2, 32); // hash
+    std::fwrite(data, sizeof(data), 1, fp);
+}
+void write_k_record(std::FILE* fp)
+{
+    // a K record has
+    // 5 byte header 
+    // 4 bytes height
+    char data[9] = {'K', 1, 0, 0, 0 };
+    memset(&data[5], 1, 4); // height
+    std::fwrite(data, sizeof(data), 1, fp);
+}
+void write_t_record(std::FILE* fp)
+{
+    // a T record has
+    // 5 byte header 
+    // 4 bytes height
+    // 4 bytes timestamp
+    char data[13] = {'T', 1, 0, 0, 0 };
+    memset(&data[5], 1, 4); // height
+    memset(&data[9], 2, 4); // timestamp
+    std::fwrite(data, sizeof(data), 1, fp);
+}
+void write_r_record(std::FILE* fp)
+{
+    // an R record has
+    // 5 byte header 
+    // 32 byte txid
+    // 2 byte v
+    // 8 byte ovalue
+    // 2 byte olen
+    // olen bytes of data
+    char data[65583] = {'R', 1, 0, 0, 0 };
+    memset(&data[5], 1, 32); // txid
+    memset(&data[37], 2, 2); // v
+    memset(&data[39], 3, 8); // ovalue
+    unsigned char olen[2] = {254, 255}; // 65534
+    memcpy(&data[47], olen, 2);
+    memset(&data[49], 4, 65534);
+    std::fwrite(data, sizeof(data), 1, fp);
+}
+void write_v_record(std::FILE* fp)
+{
+    // a V record has
+    // 5 byte header 
+    // 1 byte counter
+    // counter * 4 bytes of data
+    char data[146] = {'V', 1, 0, 0, 0};
+    memset(&data[5], 35, 1); // counter
+    memset(&data[6], 1, 140); // data
+    std::fwrite(data, sizeof(data), 1, fp);
+}
+
+/****
+ * The main purpose of this test is to verify that
+ * state files created continue to be readable despite logic
+ * changes. Files need to be readable. The record format should 
+ * not change without hardfork protection
+ */
+TEST(TestEvents, komodo_faststateinit_test)
+{
+    strcpy(ASSETCHAINS_SYMBOL, "TST");
+    KOMODO_EXTERNAL_NOTARIES = 1;
+
+    boost::filesystem::path temp = boost::filesystem::unique_path();
+    boost::filesystem::create_directories(temp);
+    try
+    {
+        // NOTE: header contains a 5 byte header that is make up of
+        // an 8 bit identifier (i.e. 'P', 'N', etc.)
+        // plus a 32 bit height. Everything else is record specific
+        // pubkey record
+        {
+            // create a binary file that should be readable by komodo
+            const std::string temp_filename = temp.native() + "/kstate.tmp";
+            char full_filename[temp_filename.size()+1];
+            strcpy(full_filename, temp_filename.c_str());
+            std::FILE* fp = std::fopen(full_filename, "wb+");
+            ASSERT_NE(fp, nullptr);
+            write_p_record(fp);
+            std::fclose(fp);
+            // verify file still exists
+            ASSERT_TRUE(boost::filesystem::exists(full_filename));
+            // attempt to read the file
+            char symbol[] = "TST";
+            komodo_state* state = komodo_stateptrget((char*)symbol);
+            ASSERT_NE(state, nullptr);
+            char* dest = nullptr;
+            // attempt to read the file
+            int32_t result = komodo_faststateinit( state, full_filename, symbol, dest);
+            // compare results
+            ASSERT_EQ(result, 1);
+            // The first and second event should be pub keys
+            ASSERT_EQ(state->Komodo_numevents, 1);
+            komodo_event* ev1 = state->Komodo_events[0];
+            ASSERT_EQ(ev1->height, 1);
+            ASSERT_EQ(ev1->type, 'P');
+        }
+        // notarized record
+        {
+            const std::string temp_filename = temp.native() + "/notarized.tmp";
+            char full_filename[temp_filename.size()+1];
+            strcpy(full_filename, temp_filename.c_str());
+            std::FILE* fp = std::fopen(full_filename, "wb+");
+            ASSERT_NE(fp, nullptr);
+            write_n_record(fp);
+            std::fclose(fp);
+            // verify file still exists
+            ASSERT_TRUE(boost::filesystem::exists(full_filename));
+            // attempt to read the file
+            char symbol[] = "TST";
+            komodo_state* state = komodo_stateptrget((char*)symbol);
+            ASSERT_NE(state, nullptr);
+            char* dest = (char*)"123456789012345";
+            // attempt to read the file
+            int32_t result = komodo_faststateinit( state, full_filename, symbol, dest);
+            // compare results
+            ASSERT_EQ(result, 1);
+            ASSERT_EQ(state->Komodo_numevents, 2);
+            komodo_event* ev = state->Komodo_events[1];
+            ASSERT_EQ(ev->height, 1);
+            ASSERT_EQ(ev->type, 'N');
+        }
+        // notarized M record
+        {
+            const std::string temp_filename = temp.native() + "/notarized.tmp";
+            char full_filename[temp_filename.size()+1];
+            strcpy(full_filename, temp_filename.c_str());
+            std::FILE* fp = std::fopen(full_filename, "wb+");
+            ASSERT_NE(fp, nullptr);
+            write_m_record(fp);
+            std::fclose(fp);
+            // verify file still exists
+            ASSERT_TRUE(boost::filesystem::exists(full_filename));
+            // attempt to read the file
+            char symbol[] = "TST";
+            komodo_state* state = komodo_stateptrget((char*)symbol);
+            ASSERT_NE(state, nullptr);
+            char* dest = (char*)"123456789012345";
+            // attempt to read the file
+            int32_t result = komodo_faststateinit(state, full_filename, symbol, dest);
+            // compare results
+            ASSERT_EQ(result, 1);
+            ASSERT_EQ(state->Komodo_numevents, 3);
+            komodo_event* ev = state->Komodo_events[2];
+            ASSERT_EQ(ev->height, 1);
+            ASSERT_EQ(ev->type, 'N'); // code converts "M" to "N"
+        }
+        // record type "U" (deprecated)
+        {
+            const std::string temp_filename = temp.native() + "/type_u.tmp";
+            char full_filename[temp_filename.size()+1];
+            strcpy(full_filename, temp_filename.c_str());
+            std::FILE* fp = std::fopen(full_filename, "wb+");
+            ASSERT_NE(fp, nullptr);
+            write_u_record(fp);
+            std::fclose(fp);
+            // verify file still exists
+            ASSERT_TRUE(boost::filesystem::exists(full_filename));
+            // attempt to read the file
+            char symbol[] = "TST";
+            komodo_state* state = komodo_stateptrget((char*)symbol);
+            ASSERT_NE(state, nullptr);
+            char* dest = (char*)"123456789012345";
+            // attempt to read the file
+            int32_t result = komodo_faststateinit(state, full_filename, symbol, dest);
+            // compare results
+            ASSERT_EQ(result, 1);
+            ASSERT_EQ(state->Komodo_numevents, 3); // does not get added to state
+        }
+        // record type K (KMD height)
+        {
+            const std::string temp_filename = temp.native() + "/kmdtype.tmp";
+            char full_filename[temp_filename.size()+1];
+            strcpy(full_filename, temp_filename.c_str());
+            std::FILE* fp = std::fopen(full_filename, "wb+");
+            ASSERT_NE(fp, nullptr);
+            write_k_record(fp);
+            std::fclose(fp);
+            // verify file still exists
+            ASSERT_TRUE(boost::filesystem::exists(full_filename));
+            // attempt to read the file
+            char symbol[] = "TST";
+            komodo_state* state = komodo_stateptrget((char*)symbol);
+            ASSERT_NE(state, nullptr);
+            char* dest = (char*)"123456789012345";
+            // attempt to read the file
+            int32_t result = komodo_faststateinit(state, full_filename, symbol, dest);
+            // compare results
+            ASSERT_EQ(result, 1);
+            ASSERT_EQ(state->Komodo_numevents, 4);
+            komodo_event* ev = state->Komodo_events[3];
+            ASSERT_EQ(ev->height, 1);
+            ASSERT_EQ(ev->type, 'K');            
+        }
+        // record type T (KMD height with timestamp)
+        {
+            const std::string temp_filename = temp.native() + "/kmdtypet.tmp";
+            char full_filename[temp_filename.size()+1];
+            strcpy(full_filename, temp_filename.c_str());
+            std::FILE* fp = std::fopen(full_filename, "wb+");
+            ASSERT_NE(fp, nullptr);
+            write_t_record(fp);
+            std::fclose(fp);
+            // verify file still exists
+            ASSERT_TRUE(boost::filesystem::exists(full_filename));
+            // attempt to read the file
+            char symbol[] = "TST";
+            komodo_state* state = komodo_stateptrget((char*)symbol);
+            ASSERT_NE(state, nullptr);
+            char* dest = (char*)"123456789012345";
+            // attempt to read the file
+            int32_t result = komodo_faststateinit(state, full_filename, symbol, dest);
+            // compare results
+            ASSERT_EQ(result, 1);
+            ASSERT_EQ(state->Komodo_numevents, 5);
+            komodo_event* ev = state->Komodo_events[4];
+            ASSERT_EQ(ev->height, 1);
+            ASSERT_EQ(ev->type, 'K'); // changed from T to K
+        }
+        // record type R (opreturn)
+        {
+            const std::string temp_filename = temp.native() + "/kmdtypet.tmp";
+            char full_filename[temp_filename.size()+1];
+            strcpy(full_filename, temp_filename.c_str());
+            std::FILE* fp = std::fopen(full_filename, "wb+");
+            ASSERT_NE(fp, nullptr);
+            write_r_record(fp);
+            std::fclose(fp);
+            // verify file still exists
+            ASSERT_TRUE(boost::filesystem::exists(full_filename));
+            // attempt to read the file
+            char symbol[] = "TST";
+            komodo_state* state = komodo_stateptrget((char*)symbol);
+            ASSERT_NE(state, nullptr);
+            char* dest = (char*)"123456789012345";
+            // attempt to read the file
+            int32_t result = komodo_faststateinit(state, full_filename, symbol, dest);
+            // compare results
+            ASSERT_EQ(result, 1);
+            ASSERT_EQ(state->Komodo_numevents, 6);
+            komodo_event* ev = state->Komodo_events[5];
+            ASSERT_EQ(ev->height, 1);
+            ASSERT_EQ(ev->type, 'R');
+        }
+        // record type V
+        {
+            const std::string temp_filename = temp.native() + "/kmdtypet.tmp";
+            char full_filename[temp_filename.size()+1];
+            strcpy(full_filename, temp_filename.c_str());
+            std::FILE* fp = std::fopen(full_filename, "wb+");
+            ASSERT_NE(fp, nullptr);
+            write_v_record(fp);
+            std::fclose(fp);
+            // verify file still exists
+            ASSERT_TRUE(boost::filesystem::exists(full_filename));
+            // attempt to read the file
+            char symbol[] = "TST";
+            komodo_state* state = komodo_stateptrget((char*)symbol);
+            ASSERT_NE(state, nullptr);
+            char* dest = (char*)"123456789012345";
+            // attempt to read the file
+            int32_t result = komodo_faststateinit(state, full_filename, symbol, dest);
+            // compare results
+            ASSERT_EQ(result, 1);
+            ASSERT_EQ(state->Komodo_numevents, 7);
+            komodo_event* ev = state->Komodo_events[6];
+            ASSERT_EQ(ev->height, 1);
+            ASSERT_EQ(ev->type, 'V');
+        }
+        // all together in 1 file
+        {
+            const std::string temp_filename = temp.native() + "/combined_state.tmp";
+            char full_filename[temp_filename.size()+1];
+            strcpy(full_filename, temp_filename.c_str());
+            std::FILE* fp = std::fopen(full_filename, "wb+");
+            ASSERT_NE(fp, nullptr);
+            write_p_record(fp);
+            write_n_record(fp);
+            write_m_record(fp);
+            write_u_record(fp);
+            write_k_record(fp);
+            write_t_record(fp);
+            write_r_record(fp);
+            write_v_record(fp);
+            std::fclose(fp);
+            // attempt to read the file
+            char symbol[] = "TST";
+            komodo_state* state = komodo_stateptrget((char*)symbol);
+            ASSERT_NE(state, nullptr);
+            char* dest = (char*)"123456789012345";
+            // attempt to read the file
+            int32_t result = komodo_faststateinit( state, full_filename, symbol, dest);
+            // compare results
+            ASSERT_EQ(result, 1);
+            ASSERT_EQ(state->Komodo_numevents, 14);
+            komodo_event* ev1 = state->Komodo_events[7];
+            ASSERT_EQ(ev1->height, 1);
+            ASSERT_EQ(ev1->type, 'P');
+        }
+    } 
+    catch(...)
+    {
+        FAIL() << "Exception thrown";
+    }
+    boost::filesystem::remove_all(temp);
 }
 
 } // namespace TestEvents

--- a/src/test-komodo/test_events.cpp
+++ b/src/test-komodo/test_events.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+#include <cstdio>
+#include <cstdlib>
+#include <boost/filesystem.hpp>
+//#define KOMODO_ZCASH
+//#include <komodo.h>
+
+struct komodo_state;
+int32_t komodo_faststateinit(struct komodo_state *sp,char *fname,char *symbol,char *dest);
+struct komodo_state *komodo_stateptrget(char *base);
+
+namespace TestEvents {
+
+TEST(TestEvents, komodo_faststateinit_test)
+{
+    // create a binary file that should be readable by komodo
+    boost::filesystem::path temp = boost::filesystem::unique_path();
+    boost::filesystem::create_directories(temp);
+    const std::string temp_filename = temp.native() + "/kstate.tmp";
+    char full_filename[temp_filename.size()+1];
+    strcpy(full_filename, temp_filename.c_str());
+    std::FILE* fp = std::fopen(full_filename, "wb+");
+    ASSERT_NE(fp, nullptr);
+    // a pubkey record with 2 keys
+    char data[1+4+1+(33*2)] = {'P', 1, 0, 0, 0, 2}; // public key record identifier with height of 1 plus number of keys plus keys themselves
+    memset(&data[6], 1, 33); // 1st key is all 1s
+    memset(&data[39], 2, 33); // 2nd key is all 2s
+    std::fwrite(data, sizeof(data), 1, fp);
+    std::fclose(fp);
+    // verify file still exists
+    ASSERT_TRUE(boost::filesystem::exists(full_filename));
+    // attempt to read the file
+    char symbol[] = "KMD";
+    komodo_state* state = komodo_stateptrget((char*)symbol);
+    ASSERT_NE(state, nullptr);
+    char* dest = nullptr;
+    // attempt to read the file
+    int32_t result = komodo_faststateinit( state, full_filename, symbol, dest);
+    // compare results
+    ASSERT_EQ(result, 1);
+}
+
+} // namespace TestEvents


### PR DESCRIPTION
> **Note:** This is a re-do of pr #427, based on the dev branch. An attempted rebase of that PR caused conflicts that I was not comfortable in resolving. My apologies for the inconvenience, but feel this is much safer.

I would like to use this PR to open a dialog into integrating heavier use of C++ features into the codebase. Comments are encouraged. But please send any comments about what I should or should not be working on directly to me instead of commenting here.

Status as of 2021-05-10: I believe the code sufficiently demonstrates concepts that could be used in further refactoring. I believe the code to be bug-free, but not complete, as both old and new ideologies coexist for discussion and testing purposes. More test cases are needed for edge cases that I have as yet not learned about.

Points for discussion:
1. Implementations in header files: Much of the code I have seen contains little implementation in .cpp files and most in .h header files. The disadvantages of this approach are (1) increased compile times and (2) delicate dependencies in linking libraries or executables. Moving the implementations to .cpp files does have disadvantages as well, such as objects compiled with different parameters can cause different (sometimes hard to diagnose) errors, but it is my opinion that the benefits outweigh the dangers.
2. Use the standard library where it makes sense to avoid platform-specific code. Two changes highlight the benefits here. Mutexes (std::mutex insted of pthread's version), and lists (std::list vs ptr-to-ptr lists).
3. Remove use of pointers where possible (i.e. pass references if possible, const references are even better), use reference counted pointers instead of raw pointers. The std::list vs ptr-to-ptr is an example here as well.
4. Declare necessary variables when you need them, not at the beginning of the function. This often makes the code easier to read.
5. Use exceptions where it makes sense. If the code is littered with `if` statements for error checking, consider using try/catch. This can reduce the code you need to write, as well as provide a performance boost in some instances if done correctly.
6. Use namespaces. Instead of starting each method name with `komdo_`, consider using namespace komodo. This reduces name collisions within the codebase (we know what an "event" is in komdo, and don't have to worry about puting "komodo_" in front of it, or a UI event having a name collision with it). This also often makes using your code as a library less cumbersome.
7. Use bool if you only need true/false instead of other integrals. This makes your intent clear.
8. Comment things that may be unclear. I personally use doxygen style comments on top of my functions. I hope everyone can understand my code by reading it, but sometimes it is very inconvenient to do so. Of course the evil side of comments is they are often stale or inaccurate. But the intent often remains.
9. Push implementations to where they belong. A "notary event" needs to be serialized. It is probably best that the code to do so reside close to the definition of what a notary event is. Every serialized "event" has a header, so this is probably a good time to use a hierarchy of "notary_event is an event, and knows how to serialize itself". Now reading or writing it to disk only requires code to tell a notary event to serialize/deserialize itself. The implementation code stays centralized and out of the way.
10. Refactor a little at a time. Knowing then what is known now, everyone would love to rewrite pretty much everything we've ever written. Avoid the urge. Bite-sized subsystems can be tackled. Eating the whole elephant will take time. The majority of the `komodo_events.h` file breaks point 9 above. I'd love to get rid of it, as well as big chunks of `komodo.h` for the same reason. But that would make testing and comparing the existing implementation with the refactor too much to take on in this round. So they will remain until they are no longer needed.
11. Header files should be independent. Include all the `#include` files necessary for the `.h`. This makes chasing down dependencies less of a problem at the expense of a little compile time. Use `#pragma once` to help with this.

The above points are simply opinions. I am not here to start wars. If the team decides that any (or all) of these are a bad idea, I'll happily work without using them. Explaining why they are a bad idea helps everyone, but is not required.

Reading suggestions and References: 
- [Migrating Legacy Systems](https://www.amazon.com/Migrating-Legacy-Systems-Interfaces-Incremental/dp/1558603301/ref=sr_1_2?dchild=1&keywords=migrating+legacy+systems&qid=1620656648&sr=8-2)
- [Komodo Contributing Guide](https://github.com/KomodoPlatform/komodo/blob/master/CONTRIBUTING.md) (includes recommending established standards such as [Google's](https://google.github.io/styleguide/cppguide.html) or [Bjarne Stroustrup](http://www.stroustrup.com/bs_faq2.html))
- [Bitcoin Contributor Readme](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md)
- [Bitcoin Developer Notes and Coding Style Guidelines](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md)