### PR TITLE
fix cJSON* pointer compare with int

### DIFF
--- a/src/komodo_bitcoind.h
+++ b/src/komodo_bitcoind.h
@@ -529,7 +529,7 @@ int32_t komodo_verifynotarization(char *symbol,char *dest,int32_t height,int32_t
     {
         if ( (json= cJSON_Parse(jsonstr)) != 0 )
         {
-            if ( (txjson= jobj(json,(char *)"result")) != 0 && (vouts= jarray(&n,txjson,(char *)"vout")) > 0 )
+            if ( (txjson= jobj(json,(char *)"result")) != 0 && (vouts= jarray(&n,txjson,(char *)"vout")) != 0 )
             {
                 vout = jitem(vouts,n-1);
                 if ( 0 && ASSETCHAINS_SYMBOL[0] != 0 )


### PR DESCRIPTION
this also will fix build on OS with default compiler - gcc 11.1.x
such as archlinux 5.2.16 and others.

(c) https://github.com/DeckerSU/KomodoOcean/commit/f4ed74c66beb6abf329c7e9fb3af3b3fb6199c8f