### PR TITLE
change zcash params files location to self-hosted

### DIFF
--- a/zcutil/VerusCoin.xml
+++ b/zcutil/VerusCoin.xml
@@ -252,7 +252,7 @@
                     <filename>${windows_folder_appdata}/ZcashParams/sprout-proving.key</filename>
                     <progressText>Zcash Params file: sprout-proving.key</progressText>
                     <showMessageOnError>0</showMessageOnError>
-                    <url>https://z.cash/downloads/sprout-proving.key</url>
+                    <url>https://komodoplatform.com/downloads/sprout-proving.key</url>
                 </httpGet>
             </actionList>
             <ruleList>
@@ -274,7 +274,7 @@
                     <filename>${windows_folder_appdata}/ZcashParams/sprout-verifying.key</filename>
                     <progressText>Zcash Params file: sprout-verifying.key</progressText>
                     <showMessageOnError>0</showMessageOnError>
-                    <url>https://z.cash/downloads/sprout-verifying.key</url>
+                    <url>https://komodoplatform.com/downloads/sprout-verifying.key</url>
                 </httpGet>
             </actionList>
             <ruleList>

--- a/zcutil/fetch-params.bat
+++ b/zcutil/fetch-params.bat
@@ -6,23 +6,23 @@ MKDIR "%APPDATA%"\ZcashParams
 )
 IF NOT EXIST "%APPDATA%"\ZcashParams\sprout-proving.key (
     ECHO Downloading Zcash trusted setup sprout-proving.key, this may take a while ...
-    .\wget64.exe --progress=dot:giga --continue --retry-connrefused --waitretry=3 --timeout=30 https://z.cash/downloads/sprout-proving.key -O "%APPDATA%"\ZcashParams\sprout-proving.key
+    .\wget64.exe --progress=dot:giga --continue --retry-connrefused --waitretry=3 --timeout=30 https://komodoplatform.com/downloads/sprout-proving.key -O "%APPDATA%"\ZcashParams\sprout-proving.key
 )
 IF NOT EXIST "%APPDATA%"\ZcashParams\sprout-verifying.key (
     ECHO Downloading Zcash trusted setup sprout-verifying.key, this may take a while ...
-    .\wget64.exe --progress=dot:giga --continue --retry-connrefused --waitretry=3 --timeout=30 https://z.cash/downloads/sprout-verifying.key -O "%APPDATA%"\ZcashParams\sprout-verifying.key
+    .\wget64.exe --progress=dot:giga --continue --retry-connrefused --waitretry=3 --timeout=30 https://komodoplatform.com/downloads/sprout-verifying.key -O "%APPDATA%"\ZcashParams\sprout-verifying.key
 )
 IF NOT EXIST "%APPDATA%"\ZcashParams\sapling-spend.params (
     ECHO Downloading Zcash trusted setup sprout-proving.key, this may take a while ...
-    .\wget64.exe --progress=dot:giga --continue --retry-connrefused --waitretry=3 --timeout=30 https://z.cash/downloads/sapling-spend.params -O "%APPDATA%"\ZcashParams\sapling-spend.params
+    .\wget64.exe --progress=dot:giga --continue --retry-connrefused --waitretry=3 --timeout=30 https://komodoplatform.com/downloads/sapling-spend.params -O "%APPDATA%"\ZcashParams\sapling-spend.params
 )
 IF NOT EXIST "%APPDATA%"\ZcashParams\sapling-output.params (
     ECHO Downloading Zcash trusted setup sprout-verifying.key, this may take a while ...
-    .\wget64.exe --progress=dot:giga --continue --retry-connrefused --waitretry=3 --timeout=30 https://z.cash/downloads/sapling-output.params -O "%APPDATA%"\ZcashParams\sapling-output.params
+    .\wget64.exe --progress=dot:giga --continue --retry-connrefused --waitretry=3 --timeout=30 https://komodoplatform.com/downloads/sapling-output.params -O "%APPDATA%"\ZcashParams\sapling-output.params
 )
 IF NOT EXIST "%APPDATA%"\ZcashParams\sprout-groth16.params (
     ECHO Downloading Zcash trusted setup sprout-verifying.key, this may take a while ...
-    .\wget64.exe --progress=dot:giga --continue --retry-connrefused --waitretry=3 --timeout=30 https://z.cash/downloads/sprout-groth16.params -O "%APPDATA%"\ZcashParams\sprout-groth16.params
+    .\wget64.exe --progress=dot:giga --continue --retry-connrefused --waitretry=3 --timeout=30 https://komodoplatform.com/downloads/sprout-groth16.params -O "%APPDATA%"\ZcashParams\sprout-groth16.params
 )
 goto :EOF
 :GET_CURRENT_DIR

--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -13,7 +13,7 @@ SPROUT_VKEY_NAME='sprout-verifying.key'
 SAPLING_SPEND_NAME='sapling-spend.params'
 SAPLING_OUTPUT_NAME='sapling-output.params'
 SAPLING_SPROUT_GROTH16_NAME='sprout-groth16.params'
-SPROUT_URL="https://z.cash/downloads"
+SPROUT_URL="https://komodoplatform.com/downloads"
 SPROUT_IPFS="/ipfs/QmZKKx7Xup7LiAtFRhYsE1M7waXcv9ir9eCECyXAFGxhEo"
 
 SHA256CMD="$(command -v sha256sum || echo shasum)"


### PR DESCRIPTION
as zcash seems delete sprout related files (sprout-proving.key,
sprout-verifying.key) from their hosting (z.cash), we need
to switch on our one hosting to download these files, as komodo
still needed them.