### PR TITLE
Allow help text even during node warmup

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -857,7 +857,7 @@ UniValue CRPCTable::execute(const std::string &strMethod, const UniValue &params
     // Return immediately if in warmup
     {
         LOCK(cs_rpcWarmup);
-        if (fRPCInWarmup)
+        if (fRPCInWarmup && strMethod != "help")
             throw JSONRPCError(RPC_IN_WARMUP, rpcWarmupStatus);
     }
 


### PR DESCRIPTION
Fixes #432

This will allow the server to reply to the help rpc call even if the server is not fully warmed up.

NOTE: Implementations of new RPC functionality must assure that nothing is done if the help boolean is set to true.