### PR TITLE
fix build with gcc 5.4.0

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,11 +83,18 @@ $(LIBUNIVALUE): $(wildcard univalue/lib/*)
 $(LIBCRYPTOCONDITIONS): $(wildcard cryptoconditions/src/*) $(wildcard cryptoconditions/include/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F) OPTFLAGS="-O2 -march=x86-64 -g "
 
-%.o: %.c
-	$(CC) -c -o $@ $<
+#%.o: %.c
+#	$(CC) -c -o $@ $<
 
-$(LIBCJSON): cJSON.o komodo_cJSON.o komodo_cutils.o
-	$(AR) cr $(LIBCJSON) $^
+#$(LIBCJSON): cJSON.o komodo_cJSON.o komodo_cutils.o
+#	$(AR) cr $(LIBCJSON) $^
+
+# libcjson build
+LIBCJSON=libcjson.a
+libcjson_a_SOURCES = cJSON.c \
+  komodo_cJSON.c komodo_cutils.cpp
+libcjson_a_CPPFLAGS=-fPIC
+EXTRA_LIBRARIES += $(LIBCJSON)
 
 # Make is not made aware of per-object dependencies to avoid limiting building parallelization
 # But to build the less dependent modules first, we manually select their order here:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -278,6 +278,7 @@ libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 # server: zcashd
 libbitcoin_server_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
 libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+libbitcoin_server_a_CPPFLAGS += -fPIC
 libbitcoin_server_a_SOURCES = \
   sendalert.cpp \
   addrman.cpp \


### PR DESCRIPTION
without these changes you will catch several linkage errors, like:

```
/usr/bin/ld: libbitcoin_server.a(libbitcoin_server_a-mini-gmp.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
libbitcoin_server.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
```
More detailed information:
https://github.com/DeckerSU/komodo/commit/d99e7d205ba42ff1a2c4138a2910e56b91eec096



