### PR TITLE
fix init of event_notarized dest field

### DIFF
--- a/src/komodo.cpp
+++ b/src/komodo.cpp
@@ -65,7 +65,7 @@ int32_t komodo_parsestatefile(struct komodo_state *sp,FILE *fp,char *symbol,char
             }
             else if ( func == 'N' || func == 'M' )
             {
-                std::shared_ptr<komodo::event_notarized> evt = std::make_shared<komodo::event_notarized>(fp, ht, func == 'M');
+                std::shared_ptr<komodo::event_notarized> evt = std::make_shared<komodo::event_notarized>(fp, ht, dest, func == 'M');
                 komodo_eventadd_notarized(sp, symbol, ht, evt);
             }
             else if ( func == 'U' ) // deprecated
@@ -134,7 +134,7 @@ int32_t komodo_parsestatefiledata(struct komodo_state *sp,uint8_t *filedata,long
             else if ( func == 'N' || func == 'M' )
             {
                 std::shared_ptr<komodo::event_notarized> ntz = 
-                        std::make_shared<komodo::event_notarized>(filedata, fpos, datalen, ht, func == 'M');
+                        std::make_shared<komodo::event_notarized>(filedata, fpos, datalen, ht, dest, func == 'M');
                 komodo_eventadd_notarized(sp, symbol, ht, ntz);
             }
             else if ( func == 'U' ) // deprecated
@@ -292,8 +292,7 @@ void komodo_stateupdate(int32_t height,uint8_t notarypubs[][33],uint8_t numnotar
         {
             if ( sp != 0 )
             {
-                std::shared_ptr<komodo::event_notarized> evt = std::make_shared<komodo::event_notarized>(height);
-                memcpy(evt->dest, dest, sizeof(evt->dest)-1);
+                std::shared_ptr<komodo::event_notarized> evt = std::make_shared<komodo::event_notarized>(height, dest);
                 evt->blockhash = sp->NOTARIZED_HASH;
                 evt->desttxid = sp->NOTARIZED_DESTTXID;
                 evt->notarizedheight = sp->NOTARIZED_HEIGHT;

--- a/src/komodo_structs.cpp
+++ b/src/komodo_structs.cpp
@@ -171,9 +171,10 @@ std::ostream& operator<<(std::ostream& os, const event_rewind& in)
     return os;
 }
 
-event_notarized::event_notarized(uint8_t *data, long &pos, long data_len, int32_t height, bool includeMoM) 
+event_notarized::event_notarized(uint8_t *data, long &pos, long data_len, int32_t height, const char* _dest, bool includeMoM)
         : event(EVENT_NOTARIZED, height), MoMdepth(0)
 {
+    memcpy(this->dest, _dest, sizeof(this->dest)-1);
     MoM.SetNull();
     mem_read(this->notarizedheight, data, pos, data_len);
     mem_read(this->blockhash, data, pos, data_len);
@@ -185,9 +186,10 @@ event_notarized::event_notarized(uint8_t *data, long &pos, long data_len, int32_
     }
 }
 
-event_notarized::event_notarized(FILE* fp, int32_t height, bool includeMoM) 
+event_notarized::event_notarized(FILE* fp, int32_t height, const char* _dest, bool includeMoM)
         : event(EVENT_NOTARIZED, height), MoMdepth(0)
 {
+    memcpy(this->dest, _dest, sizeof(this->dest)-1);
     MoM.SetNull();
     if ( fread(&notarizedheight,1,sizeof(notarizedheight),fp) != sizeof(notarizedheight) )
         throw parse_error("Invalid notarization height");

--- a/src/komodo_structs.h
+++ b/src/komodo_structs.h
@@ -117,10 +117,14 @@ std::ostream& operator<<(std::ostream& os, const event_rewind& in);
 
 struct event_notarized : public event
 {
-    event_notarized() : event(komodo_event_type::EVENT_NOTARIZED, 0), notarizedheight(0), MoMdepth(0) {}
-    event_notarized(int32_t ht) : event(EVENT_NOTARIZED, ht), notarizedheight(0), MoMdepth(0) {}
-    event_notarized(uint8_t* data, long &pos, long data_len, int32_t height, bool includeMoM = false);
-    event_notarized(FILE* fp, int32_t ht, bool includeMoM = false);
+    event_notarized() : event(komodo_event_type::EVENT_NOTARIZED, 0), notarizedheight(0), MoMdepth(0) {
+        memset(this->dest, 0, sizeof(this->dest));
+    }
+    event_notarized(int32_t ht, const char* _dest) : event(EVENT_NOTARIZED, ht), notarizedheight(0), MoMdepth(0) {
+        memcpy(this->dest, _dest, sizeof(this->dest)-1);
+    }
+    event_notarized(uint8_t* data, long &pos, long data_len, int32_t height, const char* _dest, bool includeMoM = false);
+    event_notarized(FILE* fp, int32_t ht, const char* _dest, bool includeMoM = false);
     uint256 blockhash;
     uint256 desttxid;
     uint256 MoM; 


### PR DESCRIPTION
Fix `[COIN] verifynotarization error unexpected dest.(...)` error.

@jmjatlanta @dimxy @ca333 plz, review it.

**p.s.** As we forgot to init `dest` field in two places, i made it part of ctor's to prevent such mistakes in future.