### PR TITLE
Assure last char of event_notarized::dest is 0

### DIFF
--- a/src/komodo_structs.cpp
+++ b/src/komodo_structs.cpp
@@ -175,6 +175,7 @@ event_notarized::event_notarized(uint8_t *data, long &pos, long data_len, int32_
         : event(EVENT_NOTARIZED, height), MoMdepth(0)
 {
     memcpy(this->dest, _dest, sizeof(this->dest)-1);
+    this->dest[sizeof(this->dest)-1] = 0;
     MoM.SetNull();
     mem_read(this->notarizedheight, data, pos, data_len);
     mem_read(this->blockhash, data, pos, data_len);
@@ -190,6 +191,7 @@ event_notarized::event_notarized(FILE* fp, int32_t height, const char* _dest, bo
         : event(EVENT_NOTARIZED, height), MoMdepth(0)
 {
     memcpy(this->dest, _dest, sizeof(this->dest)-1);
+    this->dest[sizeof(this->dest)-1] = 0;
     MoM.SetNull();
     if ( fread(&notarizedheight,1,sizeof(notarizedheight),fp) != sizeof(notarizedheight) )
         throw parse_error("Invalid notarization height");

--- a/src/komodo_structs.h
+++ b/src/komodo_structs.h
@@ -121,7 +121,7 @@ struct event_notarized : public event
         memset(this->dest, 0, sizeof(this->dest));
     }
     event_notarized(int32_t ht, const char* _dest) : event(EVENT_NOTARIZED, ht), notarizedheight(0), MoMdepth(0) {
-        memcpy(this->dest, _dest, sizeof(this->dest)-1);
+        memcpy(this->dest, _dest, sizeof(this->dest)-1); this->dest[sizeof(this->dest)-1] = 0;
     }
     event_notarized(uint8_t* data, long &pos, long data_len, int32_t height, const char* _dest, bool includeMoM = false);
     event_notarized(FILE* fp, int32_t ht, const char* _dest, bool includeMoM = false);


### PR DESCRIPTION
The `dest` member of the `event_notarized` class could end up without a null terminator in some instances. This fix eliminates the possibility.