### PR TITLE
Properly initialize event_pubkeys

### DIFF
--- a/src/komodo_structs.cpp
+++ b/src/komodo_structs.cpp
@@ -135,7 +135,7 @@ std::ostream& operator<<(std::ostream& os, const event& in)
  * @param pos the starting position (will advance)
  * @param data_len full length of data
  */
-event_pubkeys::event_pubkeys(uint8_t* data, long& pos, long data_len, int32_t height) : event(EVENT_PUBKEYS, height)
+event_pubkeys::event_pubkeys(uint8_t* data, long& pos, long data_len, int32_t height) : event_pubkeys(height)
 {
     num = data[pos++];
     if (num > 64)
@@ -143,7 +143,7 @@ event_pubkeys::event_pubkeys(uint8_t* data, long& pos, long data_len, int32_t he
     mem_nread(pubkeys, num, data, pos, data_len);
 }
 
-event_pubkeys::event_pubkeys(FILE* fp, int32_t height) : event(EVENT_PUBKEYS, height)
+event_pubkeys::event_pubkeys(FILE* fp, int32_t height) : event_pubkeys(height)
 {
     num = fgetc(fp);
     if ( fread(pubkeys,33,num,fp) != num )
@@ -160,7 +160,7 @@ std::ostream& operator<<(std::ostream& os, const event_pubkeys& in)
     return os;
 }
 
-event_rewind::event_rewind(uint8_t *data, long &pos, long data_len, int32_t height) : event(EVENT_REWIND, height)
+event_rewind::event_rewind(uint8_t *data, long &pos, long data_len, int32_t height) : event_rewind(height)
 {
     // nothing to do
 }
@@ -171,11 +171,10 @@ std::ostream& operator<<(std::ostream& os, const event_rewind& in)
     return os;
 }
 
-event_notarized::event_notarized(uint8_t *data, long &pos, long data_len, int32_t height, const char* _dest, bool includeMoM)
-        : event(EVENT_NOTARIZED, height), MoMdepth(0)
+event_notarized::event_notarized(uint8_t *data, long &pos, long data_len, int32_t height, 
+        const char* _dest, bool includeMoM)
+        : event_notarized(height, dest)
 {
-    strncpy(this->dest, _dest, sizeof(this->dest)-1);
-    this->dest[sizeof(this->dest)-1] = 0;
     MoM.SetNull();
     mem_read(this->notarizedheight, data, pos, data_len);
     mem_read(this->blockhash, data, pos, data_len);
@@ -188,10 +187,8 @@ event_notarized::event_notarized(uint8_t *data, long &pos, long data_len, int32_
 }
 
 event_notarized::event_notarized(FILE* fp, int32_t height, const char* _dest, bool includeMoM)
-        : event(EVENT_NOTARIZED, height), MoMdepth(0)
+        : event_notarized(height, dest)
 {
-    strncpy(this->dest, _dest, sizeof(this->dest)-1);
-    this->dest[sizeof(this->dest)-1] = 0;
     MoM.SetNull();
     if ( fread(&notarizedheight,1,sizeof(notarizedheight),fp) != sizeof(notarizedheight) )
         throw parse_error("Invalid notarization height");
@@ -223,7 +220,7 @@ std::ostream& operator<<(std::ostream& os, const event_notarized& in)
     return os;
 }
 
-event_u::event_u(uint8_t *data, long &pos, long data_len, int32_t height) : event(EVENT_U, height)
+event_u::event_u(uint8_t *data, long &pos, long data_len, int32_t height) : event_u(height)
 {
     mem_read(this->n, data, pos, data_len);
     mem_read(this->nid, data, pos, data_len);
@@ -231,7 +228,7 @@ event_u::event_u(uint8_t *data, long &pos, long data_len, int32_t height) : even
     mem_read(this->hash, data, pos, data_len);
 }
 
-event_u::event_u(FILE *fp, int32_t height) : event(EVENT_U, height)
+event_u::event_u(FILE *fp, int32_t height) : event_u(height)
 {
     if (fread(&n, 1, sizeof(n), fp) != sizeof(n))
         throw parse_error("Unable to read n of event U from file");
@@ -253,14 +250,16 @@ std::ostream& operator<<(std::ostream& os, const event_u& in)
     return os;
 }
 
-event_kmdheight::event_kmdheight(uint8_t* data, long &pos, long data_len, int32_t height, bool includeTimestamp) : event(EVENT_KMDHEIGHT, height)
+event_kmdheight::event_kmdheight(uint8_t* data, long &pos, long data_len, int32_t height, 
+        bool includeTimestamp) : event_kmdheight(height)
 {
     mem_read(this->kheight, data, pos, data_len);
     if (includeTimestamp)
         mem_read(this->timestamp, data, pos, data_len);
 }
 
-event_kmdheight::event_kmdheight(FILE *fp, int32_t height, bool includeTimestamp) : event(EVENT_KMDHEIGHT, height)
+event_kmdheight::event_kmdheight(FILE *fp, int32_t height, bool includeTimestamp) 
+        : event_kmdheight(height)
 {
     if ( fread(&kheight,1,sizeof(kheight),fp) != sizeof(kheight) )
         throw parse_error("Unable to parse KMD height");
@@ -280,7 +279,8 @@ std::ostream& operator<<(std::ostream& os, const event_kmdheight& in)
     return os;
 }
 
-event_opreturn::event_opreturn(uint8_t *data, long &pos, long data_len, int32_t height) : event(EVENT_OPRETURN, height)
+event_opreturn::event_opreturn(uint8_t *data, long &pos, long data_len, int32_t height) 
+        : event_opreturn(height)
 {
     mem_read(this->txid, data, pos, data_len);
     mem_read(this->vout, data, pos, data_len);
@@ -294,7 +294,7 @@ event_opreturn::event_opreturn(uint8_t *data, long &pos, long data_len, int32_t 
     }
 }
 
-event_opreturn::event_opreturn(FILE* fp, int32_t height) : event(EVENT_OPRETURN, height)
+event_opreturn::event_opreturn(FILE* fp, int32_t height) : event_opreturn(height)
 {
     if ( fread(&txid,1,sizeof(txid),fp) != sizeof(txid) )
         throw parse_error("Unable to parse txid of opreturn record");
@@ -322,7 +322,8 @@ std::ostream& operator<<(std::ostream& os, const event_opreturn& in)
     return os;
 }
 
-event_pricefeed::event_pricefeed(uint8_t *data, long &pos, long data_len, int32_t height) : event(EVENT_PRICEFEED, height)
+event_pricefeed::event_pricefeed(uint8_t *data, long &pos, long data_len, int32_t height) 
+        : event_pricefeed(height)
 {
     mem_read(this->num, data, pos, data_len);
     // we're only interested if there are 35 prices. 
@@ -333,7 +334,8 @@ event_pricefeed::event_pricefeed(uint8_t *data, long &pos, long data_len, int32_
         pos += num * sizeof(uint32_t);
 }
 
-event_pricefeed::event_pricefeed(FILE* fp, int32_t height) : event(EVENT_PRICEFEED, height)
+event_pricefeed::event_pricefeed(FILE* fp, int32_t height) 
+        : event_pricefeed(height)
 {
     num = fgetc(fp);
     if ( num * sizeof(uint32_t) <= sizeof(prices) && fread(prices,sizeof(uint32_t),num,fp) != num )


### PR DESCRIPTION
The intent was to call the default constructor for zero initialization. But it was not followed in all implementations of the constructor event_pubkeys. This leads to some instances where uninitialized data could be in the structure. This can lead to problems with serialization.

This fix calls the default constructor regardless of the constructor chosen.