### PR TITLE
Refactor KV

### DIFF
--- a/src/komodo.cpp
+++ b/src/komodo.cpp
@@ -204,7 +204,6 @@ void komodo_stateupdate(int32_t height,uint8_t notarypubs[][33],uint8_t numnotar
 
     if ( didinit == 0 )
     {
-        portable_mutex_init(&KOMODO_KV_mutex);
         portable_mutex_init(&KOMODO_CC_mutex);
         didinit = 1;
     }

--- a/src/komodo_extern_globals.h
+++ b/src/komodo_extern_globals.h
@@ -18,6 +18,8 @@
  * Please think twice before adding to this list. Can it be done with a better scope?
  */
 #include "komodo_structs.h"
+#include "komodo_kv.h"
+
 #include <mutex>
 #include <cstdint>
 
@@ -86,12 +88,11 @@ extern uint64_t ASSETCHAINS_CBOPRET;
 
 extern std::mutex komodo_mutex;
 extern std::vector<uint8_t> Mineropret;
-extern pthread_mutex_t KOMODO_KV_mutex;
 extern pthread_mutex_t KOMODO_CC_mutex;
-extern komodo_kv *KOMODO_KV;
 extern pax_transaction *PAX;
 extern knotaries_entry *Pubkeys;
 extern komodo_state KOMODO_STATES[34];
+extern std::shared_ptr<KV> kv;
 
 int32_t komodo_baseid(char *origbase);
 uint64_t komodo_current_supply(uint32_t nHeight);

--- a/src/komodo_gateway.cpp
+++ b/src/komodo_gateway.cpp
@@ -841,7 +841,7 @@ const char *komodo_opreturn(int32_t height,uint64_t value,uint8_t *opretbuf,int3
     tokomodo = (komodo_is_issuer() == 0);
     if ( opretbuf[0] == 'K' && opretlen != 40 )
     {
-        komodo_kvupdate(opretbuf,opretlen,value);
+        kv->update(opretbuf,opretlen,value);
         return("kv");
     }
     else if ( ASSETCHAINS_SYMBOL[0] == 0 && KOMODO_PAX == 0 )

--- a/src/komodo_globals.cpp
+++ b/src/komodo_globals.cpp
@@ -13,6 +13,9 @@
  *                                                                            *
  ******************************************************************************/
 #include "komodo_globals.h"
+#include "komodo_kv.h"
+
+std::shared_ptr<KV> kv = std::make_shared<KV>();
 
 int32_t komodo_baseid(char *origbase)
 {

--- a/src/komodo_globals.h
+++ b/src/komodo_globals.h
@@ -132,8 +132,7 @@ int32_t ASSETCHAINS_STAKED_SPLIT_PERCENTAGE;
 
 std::map <std::int8_t, int32_t> mapHeightEvalActivate;
 
-struct komodo_kv *KOMODO_KV;
-pthread_mutex_t KOMODO_KV_mutex,KOMODO_CC_mutex;
+pthread_mutex_t KOMODO_CC_mutex;
 
 #define MAX_CURRENCIES 32
 char CURRENCIES[][8] = { "USD", "EUR", "JPY", "GBP", "AUD", "CAD", "CHF", "NZD", // major currencies

--- a/src/komodo_kv.h
+++ b/src/komodo_kv.h
@@ -14,17 +14,115 @@
  ******************************************************************************/
 #pragma once
 
+/**
+ * Store key/value pairs on an assetchain via OP_RETURN
+ * See https://developers.komodoplatform.com/basic-docs/smart-chains/smart-chain-api/blockchain.html#kvupdate
+ */
 #include "komodo_defs.h"
-#include "hex.h"
+#include "uthash.h"
+#include "bits256.h"
 
-int32_t komodo_kvcmp(uint8_t *refvalue,uint16_t refvaluesize,uint8_t *value,uint16_t valuesize);
+#include <cstdint>
+#include <mutex>
 
-int32_t komodo_kvnumdays(uint32_t flags);
+struct komodo_kv 
+{ 
+    UT_hash_handle hh; 
+    bits256 pubkey; 
+    uint8_t *key;
+    uint8_t *value; 
+    int32_t height; 
+    uint32_t flags; 
+    uint16_t keylen;
+    uint16_t valuesize; 
+};
 
-int32_t komodo_kvduration(uint32_t flags);
+class KV
+{
+public:
+    /*****
+     * @brief search hash table for key
+     * @param[out] pubkeyp the public key of the found value
+     * @param[in] current_height current chain height (to check expiry)
+     * @param[out] flagsp the flags of the found value
+     * @param[out] heightp the height of the found value
+     * @param[out] value the value
+     * @param[in] key the key to search for
+     * @param[in] keylen the key length
+     * @returns -1 if not found, otherwise the size of `value`
+     */
+    int32_t search(uint256 *pubkeyp,int32_t current_height,uint32_t *flagsp,int32_t *heightp,uint8_t value[IGUANA_MAXSCRIPTSIZE],uint8_t *key,int32_t keylen);
 
-uint64_t komodo_kvfee(uint32_t flags,int32_t opretlen,int32_t keylen);
+    /****
+     * @brief add or update a kv entry
+     * @param opretbuf the entry to update
+     * @param opretlen the length of `opretbuf`
+     * @param value the fee
+     */
+    void update(uint8_t *opretbuf,int32_t opretlen,uint64_t value);
 
-int32_t komodo_kvsearch(uint256 *pubkeyp,int32_t current_height,uint32_t *flagsp,int32_t *heightp,uint8_t value[IGUANA_MAXSCRIPTSIZE],uint8_t *key,int32_t keylen);
+    /***
+     * @brief sign data with a private key
+     * @param[in] buf the data to be signed
+     * @param[in] len the length of the data in `buf`
+     * @param[in] _privkey the private key
+     * @returns the signature
+     */
+    uint256 sig(uint8_t *buf,int32_t len,uint256 _privkey);
 
-void komodo_kvupdate(uint8_t *opretbuf,int32_t opretlen,uint64_t value);
+    /*****
+     * @brief verify signature
+     * @param buf the data that was signed
+     * @param len the length of `buf`
+     * @param _pubkey the signer's public key
+     * @param sig the given signature
+     * @returns 0 if signature matches, -1 otherwise
+     */
+    bool sigverify(uint8_t *buf,int32_t len,uint256 _pubkey,uint256 sig);
+
+    /****
+     * @brief get duration via flags and block counts
+     * @param flags where number of days is stored
+     * @returns the duration
+     */
+    int32_t duration(uint32_t flags);
+
+    /*****
+     * @brief calculate fee
+     * @param flags to calculate number of days
+     * @param opretlen the size of the data
+     * @param keylen the key length
+     * @returns the fee 
+     */
+    uint64_t fee(uint32_t flags,int32_t opretlen,int32_t keylen);
+
+    /****
+     * @brief get public/private keys based on passed in information
+     * @param[out] pubkeyp the public key
+     * @param[in] passphrase the passphrase
+     * @returns the private key
+     */
+    uint256 privkey(uint256 *pubkeyp,char *passphrase);
+
+private:
+    /***
+     * Compare two values
+     * @param refvalue value A
+     * @param refvaluesize the length of value A
+     * @param value value B
+     * @param valuesize the length of value B
+     * @returns -1 if size mismatch or one of the values is null, 0 if both values are equal, < 0 if A < B, >0 if A > B
+     */
+    int32_t cmp(uint8_t *refvalue,uint16_t refvaluesize,uint8_t *value,uint16_t valuesize);
+
+    /***
+     * Retrieve number of days stored in flags
+     * @param flags where the number of days is stored (using bitwise manipulation)
+     * @returns number of days (max 365)
+     */
+    int32_t numdays(uint32_t flags);
+
+private:
+    std::mutex kv_mutex;
+    komodo_kv *KOMODO_KV;
+};

--- a/src/komodo_structs.h
+++ b/src/komodo_structs.h
@@ -54,9 +54,6 @@
 
 #include "bits256.h"
 
-// structs prior to refactor
-struct komodo_kv { UT_hash_handle hh; bits256 pubkey; uint8_t *key,*value; int32_t height; uint32_t flags; uint16_t keylen,valuesize; };
-
 struct komodo_event_notarized { uint256 blockhash,desttxid,MoM; int32_t notarizedheight,MoMdepth; char dest[16]; };
 struct komodo_event_pubkeys { uint8_t num; uint8_t pubkeys[64][33]; };
 struct komodo_event_opreturn { uint256 txid; uint64_t value; uint16_t vout,oplen; uint8_t opret[]; };

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -36,6 +36,9 @@
 #include "script/script_error.h"
 #include "script/sign.h"
 #include "script/standard.h"
+#include "komodo_defs.h"
+#include "komodo_structs.h"
+#include "komodo_kv.h"
 
 #include <stdint.h>
 
@@ -48,12 +51,11 @@
 
 using namespace std;
 
+extern std::shared_ptr<KV> kv;
 extern int32_t KOMODO_INSYNC;
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
 void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 int32_t komodo_notarized_height(int32_t *prevMoMheightp,uint256 *hashp,uint256 *txidp);
-#include "komodo_defs.h"
-#include "komodo_structs.h"
 
 double GetDifficultyINTERNAL(const CBlockIndex* blockindex, bool networkDifficulty)
 {
@@ -966,7 +968,7 @@ UniValue kvsearch(const UniValue& params, bool fHelp, const CPubKey& mypk)
         if ( keylen < sizeof(key) )
         {
             memcpy(key,params[0].get_str().c_str(),keylen);
-            if ( (valuesize= komodo_kvsearch(&refpubkey,chainActive.LastTip()->GetHeight(),&flags,&height,value,key,keylen)) >= 0 )
+            if ( (valuesize= kv->search(&refpubkey,chainActive.LastTip()->GetHeight(),&flags,&height,value,key,keylen)) >= 0 )
             {
                 std::string val; char *valuestr;
                 val.resize(valuesize);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -130,7 +130,7 @@ public:
  */
 class uint256 : public base_blob<256> {
 public:
-    uint256() {}
+    uint256() : base_blob<256>() {}
     uint256(const base_blob<256>& b) : base_blob<256>(b) {}
     explicit uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
 


### PR DESCRIPTION
This is a refactor of the KV module of komodo. This may be an unused module on asset chains, and may need archiving. Regardless, this PR cleans up the code and removes some globals.

Please note that a bug has been fixed related to signature verification. If this module is in use, please upgrade, or at least modify the old `komodo_kvsigverify` to correctly return -1 if a `_pubkey` of zeros is passed.