### PR TITLE
Clean up memory on shutdown

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -269,6 +269,8 @@ void Shutdown()
         pcoinsdbview = NULL;
         delete pblocktree;
         pblocktree = NULL;
+        delete pnotarisations;
+        pnotarisations = nullptr;
     }
 #ifdef ENABLE_WALLET
     if (pwalletMain)


### PR DESCRIPTION
The `pnotarisations` object was not `delete`d during daemon shutdown. While not a good thing, it was harmless in the past, due to the program exiting soon thereafter. However, this has recently caused problems on MacOS, so needs to be fixed.