### PR TITLE
Fix for cleanwallettransactions cleaning out immature coins

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1119,7 +1119,6 @@ UniValue cleanwallettransactions(const UniValue& params, bool fHelp, const CPubK
             + HelpExampleRpc("cleanwallettransactions","\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
         );
 
-    assert(pwalletMain != NULL);
     LOCK2(cs_main, pwalletMain->cs_wallet);
     UniValue ret(UniValue::VOBJ);
     uint256 exception; int32_t txs = pwalletMain->mapWallet.size();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1153,12 +1153,6 @@ UniValue cleanwallettransactions(const UniValue& params, bool fHelp, const CPubK
     }
     else
     {
-        // get all locked utxos to relock them later.
-        vector<COutPoint> vLockedUTXO;
-        pwalletMain->ListLockedCoins(vLockedUTXO);
-        // unlock all coins so that the following call contains all utxos.
-        pwalletMain->UnlockAllCoins();
-
         // this gets us all the txids that are unspent, we search for the oldest tx
         int32_t oldestTxDepth = 0;
         for (map<uint256, CWalletTx>::const_iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
@@ -1185,11 +1179,6 @@ UniValue cleanwallettransactions(const UniValue& params, bool fHelp, const CPubK
             }
         }
         oldestTxDepth = oldestTxDepth + 1; // add extra block just for safety.
-
-        // lock all the previouly locked coins.
-        BOOST_FOREACH(COutPoint &outpt, vLockedUTXO) {
-            pwalletMain->LockCoin(outpt);
-        }
 
         // then add all txs in the wallet before this block to the list to remove.
         for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)


### PR DESCRIPTION
The method used for listunspent excludes immature coins. `cleanwallettransactions` does not need all the data and checks from `AvailableCoins` (aka listunspent) method as it just needs the lowest blockheight below which it can clear all transactions from the wallet. 

Updated to use a simplified loop (same as what's used later in the method) through wallet transactions and basic checks against the transactions/utxos - `CheckFinalTx` and orphaned

Also assert pwalletMain exists earlier as it was used for unlocking transactions during cleanup.

Diff without whitespace cleanup https://github.com/KomodoPlatform/komodo/pull/553/files?w=1