### PR TITLE
Use a new name for komodostate file; fix loading last nota

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -35,6 +35,7 @@
 #include "httprpc.h"
 #include "key.h"
 #include "notarisationdb.h"
+#include "komodo.h"
 #include "komodo_globals.h"
 #include "komodo_notary.h"
 #include "komodo_gateway.h"
@@ -667,7 +668,7 @@ void CleanupBlockRevFiles()
                 remove(it->path());
         }
     }
-    path komodostate = GetDataDir() / "komodostate";
+    path komodostate = GetDataDir() / KOMODO_STATE_FILENAME;
     remove(komodostate);
     path minerids = GetDataDir() / "minerids";
     remove(minerids);
@@ -942,7 +943,7 @@ bool AttemptDatabaseOpen(size_t nBlockTreeDBCache, bool dbCompression, size_t db
         pnotarisations = new NotarisationDB(100*1024*1024, false, fReindex);
 
         if (fReindex) {
-            boost::filesystem::remove(GetDataDir() / "komodostate");
+            boost::filesystem::remove(GetDataDir() / KOMODO_STATE_FILENAME);
             boost::filesystem::remove(GetDataDir() / "signedmasks");
             pblocktree->WriteReindexing(true);
             //If we're reindexing in prune mode, wipe away unusable block files and all undo data files

--- a/src/komodo.cpp
+++ b/src/komodo.cpp
@@ -48,7 +48,7 @@ int32_t komodo_currentheight()
     else return(0);
 }
 
-int32_t komodo_parsestatefile(struct komodo_state *sp,FILE *fp,char *symbol,char *dest)
+int32_t komodo_parsestatefile(struct komodo_state *sp,FILE *fp,char *symbol, const char *dest)
 {
     int32_t func;
 
@@ -114,16 +114,15 @@ int32_t komodo_parsestatefile(struct komodo_state *sp,FILE *fp,char *symbol,char
     catch(const komodo::parse_error& pe)
     {
         LogPrintf("Error occurred in parsestatefile: %s\n", pe.what());
-        LogPrintf("komodostate file is invalid. Komodod will be stopped. Please remove komodostate and komodostate.ind files and start the daemon");
-        //std::cerr << std::endl << " Error in komodostate file: unknown event " << (char)func << ", exiting. Please remove komodostate and komodostate.ind files and start the daemon" << std::endl << std::endl;
-        uiInterface.ThreadSafeMessageBox(_("Please remove komodostate and komodostate.ind files and restart"), "", CClientUIInterface::MSG_ERROR);
+        LogPrintf("%s file is invalid. Komodod will be stopped. Please remove %s and %s.ind files and start the daemon\n", KOMODO_STATE_FILENAME, KOMODO_STATE_FILENAME, KOMODO_STATE_FILENAME);
+        uiInterface.ThreadSafeMessageBox(strprintf("Please remove %s and %s.ind files and restart", KOMODO_STATE_FILENAME, KOMODO_STATE_FILENAME), "", CClientUIInterface::MSG_ERROR);
         StartShutdown();            
         func = -1;
     }
     return func;
 }
 
-int32_t komodo_parsestatefiledata(struct komodo_state *sp,uint8_t *filedata,long *fposp,long datalen,char *symbol,char *dest)
+int32_t komodo_parsestatefiledata(struct komodo_state *sp,uint8_t *filedata,long *fposp,long datalen,const char *symbol, const char *dest)
 {
     int32_t func = -1;
 
@@ -191,9 +190,8 @@ int32_t komodo_parsestatefiledata(struct komodo_state *sp,uint8_t *filedata,long
     catch( const komodo::parse_error& pe)
     {
         LogPrintf("Unable to parse state file data. Error: %s\n", pe.what());
-        LogPrintf("komodostate file is invalid. Komodod will be stopped. Please remove komodostate and komodostate.ind files and start the daemon");
-        //std::cerr << std::endl << " Error in komodostate file: unknown event " << (char)func << ", exiting. Please remove komodostate and komodostate.ind files and start the daemon" << std::endl << std::endl;
-        uiInterface.ThreadSafeMessageBox(_("Please remove komodostate and komodostate.ind files and restart"), "", CClientUIInterface::MSG_ERROR);
+        LogPrintf("%s file is invalid. Komodod will be stopped. Please remove %s and %s.ind files and start the daemon\n", KOMODO_STATE_FILENAME, KOMODO_STATE_FILENAME, KOMODO_STATE_FILENAME);
+        uiInterface.ThreadSafeMessageBox(strprintf("Please remove %s and %s.ind files and restart", KOMODO_STATE_FILENAME, KOMODO_STATE_FILENAME), "", CClientUIInterface::MSG_ERROR);
         StartShutdown();
         func = -1;
     }
@@ -225,7 +223,7 @@ void komodo_stateupdate(int32_t height,uint8_t notarypubs[][33],uint8_t numnotar
     }
     if ( fp == 0 )
     {
-        komodo_statefname(fname,chainName.symbol().c_str(),(char *)"komodostate");
+        komodo_statefname(fname, chainName.symbol().c_str(), KOMODO_STATE_FILENAME);
         if ( (fp= fopen(fname,"rb+")) != nullptr )
         {
             if ( komodo_faststateinit(sp, fname, symbol, dest) )
@@ -237,6 +235,7 @@ void komodo_stateupdate(int32_t height,uint8_t notarypubs[][33],uint8_t numnotar
                 while (!ShutdownRequested() && komodo_parsestatefile(sp,fp,symbol,dest) >= 0)
                     ;
             }
+            LogPrintf("komodo read last notarised height %d from %s\n", sp->LastNotarizedHeight(), KOMODO_STATE_FILENAME);
         } 
         else 
             fp = fopen(fname,"wb+"); // the state file probably did not exist, create it.

--- a/src/komodo.h
+++ b/src/komodo.h
@@ -33,13 +33,15 @@
 //#include "komodo_ccdata.h"
 #include <cstdint>
 
-int32_t komodo_parsestatefile(struct komodo_state *sp,FILE *fp,char *symbol,char *dest);
+const char KOMODO_STATE_FILENAME[] = "komodoevents";
+
+int32_t komodo_parsestatefile(struct komodo_state *sp,FILE *fp,char *symbol, const char *dest);
 
 void komodo_currentheight_set(int32_t height);
 
 int32_t komodo_currentheight();
 
-int32_t komodo_parsestatefiledata(struct komodo_state *sp,uint8_t *filedata,long *fposp,long datalen,char *symbol,char *dest);
+int32_t komodo_parsestatefiledata(struct komodo_state *sp,uint8_t *filedata,long *fposp,long datalen,const char *symbol, const char *dest);
 
 void komodo_stateupdate(int32_t height,uint8_t notarypubs[][33],uint8_t numnotaries,uint8_t notaryid,
         uint256 txhash,uint32_t *pvals,uint8_t numpvals,int32_t KMDheight,uint32_t KMDtimestamp,

--- a/src/komodo_bitcoind.cpp
+++ b/src/komodo_bitcoind.cpp
@@ -459,7 +459,7 @@ void komodo_reconsiderblock(uint256 blockhash)
     //fprintf(stderr,"komodo_reconsiderblock.(%s) (%s %u) -> NULL\n",params,ASSETCHAINS_USERPASS,ASSETCHAINS_RPCPORT);
 }
 
-int32_t komodo_verifynotarization(char *symbol,char *dest,int32_t height,int32_t NOTARIZED_HEIGHT,uint256 NOTARIZED_HASH,uint256 NOTARIZED_DESTTXID)
+int32_t komodo_verifynotarization(const char *symbol,const char *dest,int32_t height,int32_t NOTARIZED_HEIGHT,uint256 NOTARIZED_HASH,uint256 NOTARIZED_DESTTXID)
 {
     char params[256];
     char *jsonstr = nullptr;

--- a/src/komodo_bitcoind.cpp
+++ b/src/komodo_bitcoind.cpp
@@ -480,7 +480,7 @@ int32_t komodo_verifynotarization(const char *symbol,const char *dest,int32_t he
         }//else jsonstr = _dex_getrawtransaction();
         else return(0); // need universal way to issue DEX* API, since notaries mine most blocks, this ok
     }
-    else if ( strcmp(dest,"BTC") == 0 )
+    else if ( strcmp(dest,"BTC") == 0 )     // Note: this should work for LTC too (BTC is used as an alias for LTC)
     {
         if ( BTCUSERPASS[0] != 0 )
         {

--- a/src/komodo_bitcoind.h
+++ b/src/komodo_bitcoind.h
@@ -93,7 +93,7 @@ int32_t komodo_verifynotarizedscript(int32_t height,uint8_t *script,int32_t len,
 
 void komodo_reconsiderblock(uint256 blockhash);
 
-int32_t komodo_verifynotarization(char *symbol,char *dest,int32_t height,int32_t NOTARIZED_HEIGHT,uint256 NOTARIZED_HASH,uint256 NOTARIZED_DESTTXID);
+int32_t komodo_verifynotarization(const char *symbol, const char *dest,int32_t height,int32_t NOTARIZED_HEIGHT,uint256 NOTARIZED_HASH,uint256 NOTARIZED_DESTTXID);
 
 CScript komodo_makeopret(CBlock *pblock, bool fNew);
 

--- a/src/komodo_events.cpp
+++ b/src/komodo_events.cpp
@@ -32,7 +32,7 @@
  * @param height
  * @param ntz the event
  */
-void komodo_eventadd_notarized( komodo_state *sp, char *symbol, int32_t height, komodo::event_notarized& ntz)
+void komodo_eventadd_notarized( komodo_state *sp, const char *symbol, int32_t height, komodo::event_notarized& ntz)
 {
     if ( IS_KOMODO_NOTARY 
             && komodo_verifynotarization(symbol,ntz.dest,height,ntz.notarizedheight,ntz.blockhash, ntz.desttxid) < 0 )
@@ -59,7 +59,7 @@ void komodo_eventadd_notarized( komodo_state *sp, char *symbol, int32_t height, 
  * @param height
  * @param pk the event
  */
-void komodo_eventadd_pubkeys(komodo_state *sp, char *symbol, int32_t height, komodo::event_pubkeys& pk)
+void komodo_eventadd_pubkeys(komodo_state *sp, const char *symbol, int32_t height, komodo::event_pubkeys& pk)
 {
     if (sp != nullptr)
     {
@@ -76,7 +76,7 @@ void komodo_eventadd_pubkeys(komodo_state *sp, char *symbol, int32_t height, kom
  * @param height
  * @param pf the event
  */
-void komodo_eventadd_pricefeed( komodo_state *sp, char *symbol, int32_t height, komodo::event_pricefeed& pf)
+void komodo_eventadd_pricefeed( komodo_state *sp, const char *symbol, int32_t height, komodo::event_pricefeed& pf)
 {
     if (sp != nullptr)
     {
@@ -91,7 +91,7 @@ void komodo_eventadd_pricefeed( komodo_state *sp, char *symbol, int32_t height, 
  * @param height
  * @param opret the event
  */
-void komodo_eventadd_opreturn( komodo_state *sp, char *symbol, int32_t height, komodo::event_opreturn& opret)
+void komodo_eventadd_opreturn( komodo_state *sp, const char *symbol, int32_t height, komodo::event_opreturn& opret)
 {
     if ( sp != nullptr && !chainName.isKMD() )
     {
@@ -123,7 +123,7 @@ void komodo_event_undo(komodo_state* sp, komodo::event_kmdheight& ev)
  
 
 
-void komodo_event_rewind(komodo_state *sp, char *symbol, int32_t height)
+void komodo_event_rewind(komodo_state *sp, const char *symbol, int32_t height)
 {
     if ( sp != nullptr )
     {
@@ -165,7 +165,7 @@ void komodo_setkmdheight(struct komodo_state *sp,int32_t kmdheight,uint32_t time
  * @param height
  * @param kmdht the event
  */
-void komodo_eventadd_kmdheight(struct komodo_state *sp,char *symbol,int32_t height,
+void komodo_eventadd_kmdheight(struct komodo_state *sp, const char *symbol,int32_t height,
         komodo::event_kmdheight& kmdht)
 {
     if (sp != nullptr)

--- a/src/komodo_events.h
+++ b/src/komodo_events.h
@@ -16,16 +16,16 @@
 #include "komodo_defs.h"
 #include "komodo_structs.h"
 
-void komodo_eventadd_notarized(komodo_state *sp,char *symbol,int32_t height, komodo::event_notarized& ntz);
+void komodo_eventadd_notarized(komodo_state *sp, const char *symbol,int32_t height, komodo::event_notarized& ntz);
 
-void komodo_eventadd_pubkeys(komodo_state *sp,char *symbol,int32_t height, komodo::event_pubkeys& pk);
+void komodo_eventadd_pubkeys(komodo_state *sp, const char *symbol,int32_t height, komodo::event_pubkeys& pk);
 
-void komodo_eventadd_pricefeed(komodo_state *sp,char *symbol,int32_t height, komodo::event_pricefeed& pf);
+void komodo_eventadd_pricefeed(komodo_state *sp, const char *symbol,int32_t height, komodo::event_pricefeed& pf);
 
-void komodo_eventadd_opreturn(komodo_state *sp,char *symbol,int32_t height, komodo::event_opreturn& opret);
+void komodo_eventadd_opreturn(komodo_state *sp, const char *symbol,int32_t height, komodo::event_opreturn& opret);
 
-void komodo_eventadd_kmdheight(komodo_state *sp,char *symbol,int32_t height, komodo::event_kmdheight& kmd_ht);
+void komodo_eventadd_kmdheight(komodo_state *sp, const char *symbol,int32_t height, komodo::event_kmdheight& kmd_ht);
 
-void komodo_event_rewind(komodo_state *sp,char *symbol,int32_t height);
+void komodo_event_rewind(komodo_state *sp, const char *symbol,int32_t height);
 
 void komodo_setkmdheight(komodo_state *sp,int32_t kmdheight,uint32_t timestamp);

--- a/src/komodo_gateway.cpp
+++ b/src/komodo_gateway.cpp
@@ -235,7 +235,7 @@ int32_t komodo_check_deposit(int32_t height,const CBlock& block)
     return(0);
 }
 
-void komodo_stateind_set(struct komodo_state *sp,uint32_t *inds,int32_t n,uint8_t *filedata,long datalen,char *symbol,char *dest)
+void komodo_stateind_set(struct komodo_state *sp,uint32_t *inds,int32_t n,uint8_t *filedata,long datalen,const char *symbol,const char *dest)
 {
     uint8_t func; long lastK,lastT,lastN,lastV,fpos,lastfpos; int32_t i,count,doissue,iter,numn,numv,numN,numV,numR; uint32_t tmp,prevpos100,offset;
     count = numR = numN = numV = numn = numv = 0;
@@ -380,7 +380,7 @@ uint8_t *OS_fileptr(long *allocsizep,const char *fname)
  * @return -1 on error
  */
 long komodo_stateind_validate(struct komodo_state *sp,const std::string& indfname,uint8_t *filedata,long datalen,
-        uint32_t *prevpos100p,uint32_t *indcounterp,char *symbol,char *dest)
+        uint32_t *prevpos100p,uint32_t *indcounterp,const char *symbol,const char *dest)
 {
     *indcounterp = *prevpos100p = 0;
     long fsize;
@@ -453,7 +453,7 @@ long komodo_indfile_update(FILE *indfp,uint32_t *prevpos100p,long lastfpos,long 
  * @param dest the "parent" chain
  * @return true on success
  */
-bool komodo_faststateinit(komodo_state *sp,const char *fname,char *symbol,char *dest)
+bool komodo_faststateinit(komodo_state *sp,const char *fname,char *symbol, const char *dest)
 {
     uint32_t starttime = (uint32_t)time(NULL);
 

--- a/src/komodo_gateway.h
+++ b/src/komodo_gateway.h
@@ -58,4 +58,4 @@ int32_t komodo_check_deposit(int32_t height,const CBlock& block);
  * @param dest the "parent" chain
  * @return true on success
  */
-bool komodo_faststateinit(komodo_state *sp,const char *fname,char *symbol,char *dest);
+bool komodo_faststateinit(komodo_state *sp,const char *fname,char *symbol, const char *dest);

--- a/src/komodo_utils.cpp
+++ b/src/komodo_utils.cpp
@@ -1635,17 +1635,25 @@ void komodo_args(char *argv0)
         KOMODO_EXTRASATOSHI = 1;
 }
 
+/***
+ * @brief sets 'symbol' to the current chain name, 'dest' to either KMD or BTC
+ * according to the 'source' which must be either the current asset chain name or empty (if KMD).
+ * @param[out] symbol set to the current asset chain name or "KMD"
+ * @param[out] dest set to the notarisation chain name (KMD or BTC)
+ * @param[in] source current asset chain name or empty string for KMD
+ * This function should be deprecated IMO
+ */
 void komodo_nameset(char *symbol,char *dest,const char *source)
 {
-    if ( source[0] == 0 )
+    if ( source[0] == 0 )   // if not an asset chain
     {
-        strcpy(symbol,(char *)"KMD");
-        strcpy(dest,(char *)"BTC");
+        strcpy(symbol,(char *)"KMD");   // this chain is KMD
+        strcpy(dest,(char *)"BTC");     // dest is BTC
     }
     else
     {
-        strcpy(symbol,source);
-        strcpy(dest,(char *)"KMD");
+        strcpy(symbol,source);          // this chain an asset chain
+        strcpy(dest,(char *)"KMD");     // dest is KMD
     }
 }
 


### PR DESCRIPTION
Use a new komodoevents file name instead of komodostate to avoid removing the corrupted file on startup
Fix loading last nota from komodoevents (also logging added)