### PR TITLE
update deps for 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Komodo is based on Zcash and has been extended by our innovative consensus algor
 
 ## Getting started
 
-### Dependencies
+### Dependencies (Ubuntu 20.04)
 
 ```shell
 #The following packages are needed:
-sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python python-zmq zlib1g-dev wget libcurl4-gnutls-dev bsdmainutils automake curl libsodium-dev
+sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python3 python3-zmq zlib1g-dev wget libcurl4-gnutls-dev bsdmainutils automake curl libsodium-dev
 ```
 
 ### Build Komodo


### PR DESCRIPTION
Ubuntu 18.04 is EOL in April. Current deps in README.md fail on `python python-zmq` in 20.04.5. Changing this to `python3 python3-zmq` works.