### PR TITLE
secp256k1: fix possible read from uninitialized memory (tmpj)

### DIFF
--- a/src/secp256k1/src/ecmult_impl.h
+++ b/src/secp256k1/src/ecmult_impl.h
@@ -1503,8 +1503,9 @@ static size_t secp256k1_pippenger_max_points(secp256k1_scratch *scratch) {
     secp256k1_gej tmpj;
     
     secp256k1_scalar_set_int(&szero, 0);
-    /* r = inp_g_sc*G */
     secp256k1_gej_set_infinity(r);
+    secp256k1_gej_set_infinity(&tmpj);
+    /* r = inp_g_sc*G */
     secp256k1_ecmult(ctx, r, &tmpj, &szero, inp_g_sc);
     for (point_idx = 0; point_idx < n_points; point_idx++) {
         secp256k1_ge point;


### PR DESCRIPTION
`secp256k1_ecmult_multi_var_simple` was introduced by `jl777` in `ENABLE_MODULE_MUSIG` commit https://github.com/KomodoPlatform/komodo/commit/c127a8f0b5bfd89e76364e6432c8a70b5eb3a203 . originally these changes was introduced by `jonasnick` here: https://github.com/BlockstreamResearch/secp256k1-zkp/pull/35/files#diff-dc206b3f5f973b97a0f5c1b12d705d0e58a1cb8c9684e481e7a34fc05e4716aa . eventually, the changes made in this commit were applied to Bitcoin Core via https://github.com/bitcoin-core/secp256k1/pull/580 , and during the conversation https://github.com/bitcoin-core/secp256k1/pull/580/files#r255427342 initialization of `tmpj` was added.

this fix helps to fix this error during build:

```
In file included from src/secp256k1.c:14:
In function ‘secp256k1_ecmult’,
    inlined from ‘secp256k1_ecmult_multi_var_simple’ at src/ecmult_impl.h:1508:5:
src/ecmult_impl.h:1028:5: warning: ‘tmpj’ may be used uninitialized [-Wmaybe-uninitialized]
 1028 |     secp256k1_ecmult_strauss_wnaf(ctx, &state, r, 1, a, na, ng);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/ecmult_impl.h: In function ‘secp256k1_ecmult_multi_var_simple’:
src/ecmult_impl.h:861:13: note: by argument 4 of type ‘const secp256k1_gej *’ to ‘secp256k1_ecmult_strauss_wnaf.constprop’ declared here
  861 | static void secp256k1_ecmult_strauss_wnaf(const secp256k1_ecmult_context *ctx, const struct secp256k1_strauss_state *state, secp256k1_gej *r, int num, const secp256k1_gej *a, const secp256k1_scalar *na, const secp256k1_scalar *ng) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/ecmult_impl.h:1503:19: note: ‘tmpj’ declared here
 1503 |     secp256k1_gej tmpj;
      |                   ^~~~
```