### PR TITLE
Pass CWalletDB to OrderedTxItems() as optional param

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1127,7 +1127,7 @@ public:
      * @return multimap of ordered transactions and accounting entries
      * @warning Returned pointers are *only* valid within the scope of passed acentries
      */
-    TxItems OrderedTxItems(std::list<CAccountingEntry>& acentries, std::string strAccount = "");
+    TxItems OrderedTxItems(std::list<CAccountingEntry>& acentries, std::string strAccount = "", CWalletDB *pwalletdbIn = nullptr);
 
     void MarkDirty();
     bool UpdateNullifierNoteMap();


### PR DESCRIPTION
Passing CWalletDB to OrderedTxItems() drastically speeds up importprivkey (and prevents py tests from failure on timed out importprivkey)