### PR TITLE
Improve py tests err handling

### DIFF
--- a/qa/pytest_komodo/lib/pytest_util.py
+++ b/qa/pytest_komodo/lib/pytest_util.py
@@ -442,19 +442,21 @@ def validate_template(blocktemplate, schema=''):  # BIP 0022
     jsonschema.validate(instance=blocktemplate, schema=schema)
 
 
+# two or more nodes are in sync if they have same number of blocks
 def check_synced(*proxies):
-    for proxy in proxies:
+    while True:
         tries = 0
-        while True:
-            check = proxy.getinfo().get('synced')
-            proxy.ping()
-            if check:
-                print("Synced\n")
-                break
-            else:
-                print("Waiting for sync\nAttempt: ", tries + 1, "\n")
-                time.sleep(10)
-                tries += 1
+        blocks_set = set()
+        for proxy in proxies:
+            blocks = proxy.getinfo().get('blocks')
+            blocks_set.add(blocks)
+        if  len(blocks_set) == 1: # all have same 'blocks' value
+            print("Synced\n")
+            break
+        else:
+            print("Waiting for sync\nAttempt: ", tries + 1, "\n")
+            time.sleep(10)
+            tries += 1
             if tries > 120:  # up to 20 minutes
                 return False
     return True

--- a/qa/pytest_komodo/lib/pytest_util.py
+++ b/qa/pytest_komodo/lib/pytest_util.py
@@ -375,6 +375,7 @@ def enable_mining(proxy):
     while True:
         try:
             proxy.setgenerate(True, threads_count)
+            print("mining enabled")
             break
         except Exception as e:
             print(e, " Waiting chain startup\n")
@@ -387,6 +388,7 @@ def enable_mining(proxy):
 def mine_and_waitconfirms(txid, proxy, confs_req=2):  # should be used after tx is send
     # we need the tx above to be confirmed in the next block
     attempts = 0
+    assert(txid)
     while True:
         try:
             confirmations_amount = proxy.getrawtransaction(txid, 1)['confirmations']

--- a/qa/pytest_komodo/lib/util.py
+++ b/qa/pytest_komodo/lib/util.py
@@ -16,6 +16,7 @@ def assert_error(result):
 
 def check_if_mined(rpc_connection, txid):
     attempts = 0
+    assert(txid)
     while True:
         try:
             confirmations_amount = rpc_connection.getrawtransaction(txid, 1)["confirmations"]


### PR DESCRIPTION
I'd like to propose a few fixes to python tests from my recent experience:
* check_synced py function may never return true. I propose a more reliable algo which simply checks that all nodes have same blocks number (More info: check_synced uses getinfo()['synced'] flag which relies on KOMODO_LONGESTCHAIN variable which sometimes may not be equal to the chain tip - it depends on which node started syncing)
* a getinfo call is used to check if komodod is started, it may return empty response -  added handling for that
* importprivkey and even the next validateaddress call in py may time out in tests due to long ScanForWalletTransactions() run - added a wait loop for that
* in check_if_mined added assert(txid) so it would fail the test if a tx creation failed
* in test_channels.py test that uses setban add clearbanned even if the test failed