### PR TITLE
New and fixed tests for future blocktime, komodo interest, max script size

### DIFF
--- a/src/test-komodo/test_kmd_feat.cpp
+++ b/src/test-komodo/test_kmd_feat.cpp
@@ -17,7 +17,7 @@
 #include "komodo_interest.h"
 #include "cc/CCinclude.h"
 #include "komodo_hardfork.h"
-
+#include "testutils.h"
 
 CCriticalSection& get_cs_main(); // in main.cpp
 
@@ -121,7 +121,11 @@ protected:
 };
 
 // some komodo consensus extensions
+
+// test komodo_interest_validate function which ensures tx nLockTime is no too old
 TEST_F(KomodoFeatures, komodo_interest_validate) {
+
+    CTestBlockWriter wr; // create temp dir for writing blocks
 
     // Add a fake transaction to the wallet
     CMutableTransaction mtx0 = CreateNewContextualCMutableTransaction(Params().GetConsensus(), komodo_interest_height-1);
@@ -140,7 +144,11 @@ TEST_F(KomodoFeatures, komodo_interest_validate) {
     pfakeIndex->pprev = nullptr;
     pfakeIndex->nHeight = komodo_interest_height-1;
     pfakeIndex->nTime = 1663755146;
-    mapBlockIndex.insert(std::make_pair(blockHash, pfakeIndex));
+
+    BlockMap::iterator pi = mapBlockIndex.insert(std::make_pair(blockHash, pfakeIndex)).first;
+    pfakeIndex->phashBlock = &((*pi).first);
+    wr.WriteBlock(block, pfakeIndex, pfakeIndex->nHeight);
+
     chainActive.SetTip(pfakeIndex);
     EXPECT_TRUE(chainActive.Contains(pfakeIndex));
     EXPECT_EQ(komodo_interest_height-1, chainActive.Height());

--- a/src/test-komodo/testutils.cpp
+++ b/src/test-komodo/testutils.cpp
@@ -82,6 +82,21 @@ void setConsoleDebugging(bool enable)
     fPrintToConsole = enable;
 }
 
+static bool fDebugSaved = false;
+static bool fPrintToConsoleSaved = false;
+void enableDebug()
+{
+    fDebugSaved = fDebug;
+    fPrintToConsoleSaved = fPrintToConsole;
+    fDebug = true;
+    fPrintToConsole = true;
+}
+void restoreDebug()
+{
+    fDebug = fDebugSaved;
+    fPrintToConsole = fPrintToConsoleSaved;
+}
+
 void setupChain()
 {
     SelectParams(CBaseChainParams::REGTEST);

--- a/src/test-komodo/testutils.h
+++ b/src/test-komodo/testutils.h
@@ -196,3 +196,22 @@ public:
 private:
     CKey key;
 };
+
+// CTestBlockWriter to write a block in a temp dir
+// to provide GetTransaction() calls to work in tests 
+class CTestBlockWriter {
+public:
+    CTestBlockWriter() {
+        InitTempDir();
+    }
+    ~CTestBlockWriter() {
+        CleanTempDir();
+    }
+    void WriteBlock(CBlock &block, CBlockIndex *pindex, int32_t nHeight);
+
+private:
+    void InitTempDir();
+    void CleanTempDir();
+    boost::filesystem::path dataDir;
+};
+

--- a/src/test-komodo/testutils.h
+++ b/src/test-komodo/testutils.h
@@ -28,6 +28,8 @@ void displayTransaction(const CTransaction& tx);
 void displayBlock(const CBlock& blk);
 
 void setConsoleDebugging(bool enable);
+void enableDebug();
+void restoreDebug();
 
 void setupChain();
 /***


### PR DESCRIPTION
New and fixed tests (in komodo-test executable):
added new test to ensure valid blocktime in future
pulled test for max script element size from the original test set
added test for spending uxto with interest, refactored test for getting value with interest (used temp block file for GetTransaction to work)