### PR TITLE
update rust to 1.69.0

### DIFF
--- a/.github/workflows/komodo_mac_ci.yml
+++ b/.github/workflows/komodo_mac_ci.yml
@@ -18,7 +18,6 @@ jobs:
       # Workaround for https://github.com/actions/setup-python/issues/577
       - name: Clean up binaries and links (macOS)
         run: |
-          brew unlink node
           rm -f /usr/local/bin/2to3-3.*
           rm -f /usr/local/bin/idle3.*
           rm -f /usr/local/bin/pydoc3.*

--- a/.github/workflows/komodo_mac_ci.yml
+++ b/.github/workflows/komodo_mac_ci.yml
@@ -15,6 +15,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Workaround for https://github.com/actions/setup-python/issues/577
+      - name: Clean up binaries and links (macOS)
+        run: |
+          brew unlink node
+          rm -f /usr/local/bin/2to3-3.*
+          rm -f /usr/local/bin/idle3.*
+          rm -f /usr/local/bin/pydoc3.*
+          rm -f /usr/local/bin/python3.*
+          rm -f /usr/local/bin/2to3
+          rm -f /usr/local/bin/idle3
+          rm -f /usr/local/bin/pydoc3
+          rm -f /usr/local/bin/python3
+          rm -f /usr/local/bin/python3-config
+
       - name: Install deps (macOS)
         run: |
           brew update

--- a/contrib/devtools/update-rust-hashes.sh
+++ b/contrib/devtools/update-rust-hashes.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+export LC_ALL=C
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+RUST_PACKAGE="$SCRIPT_DIR/../../depends/packages/rust.mk"
+
+RUST_VERSION=$( grep -oP "_version=\K.*" $RUST_PACKAGE )
+
+update_hash() {
+    url="https://static.rust-lang.org/dist/$1-$RUST_VERSION-$2.tar.gz"
+    echo "Fetching $url"
+    hash=$( curl $url | sha256sum | awk '{print $1}' )
+    sed -i "/\$(package)_$3_$4=/c\\\$(package)_$3_$4=$hash" $RUST_PACKAGE
+}
+
+update_rust_hash() {
+    update_hash rust $1 sha256_hash $2
+}
+
+update_stdlib_hash() {
+    update_hash rust-std $1 rust_std_sha256_hash $1
+}
+
+# For native targets
+# update_rust_hash RUST_TARGET MAKEFILE_PACKAGE_IDENTIFIER
+update_rust_hash aarch64-unknown-linux-gnu aarch64_linux
+update_rust_hash x86_64-apple-darwin darwin
+update_rust_hash x86_64-unknown-linux-gnu linux
+update_rust_hash x86_64-unknown-freebsd freebsd
+update_rust_hash x86_64-pc-windows-gnu mingw32
+
+# For cross-compilation targets
+# update_stdlib_hash RUST_TARGET
+# update_stdlib_hash aarch64-unknown-linux-gnu
+# update_stdlib_hash x86_64-apple-darwin
+# update_stdlib_hash x86_64-pc-windows-gnu
+# update_stdlib_hash x86_64-unknown-freebsd

--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -9,7 +9,7 @@ $(package)_dependencies=rust $(rust_crates)
 $(package)_patches=cargo.config 0001-Start-using-cargo-clippy-for-CI.patch remove-dev-dependencies.diff
 
 ifeq ($(host_os),mingw32)
-$(package)_library_file=target/x86_64-pc-windows-gnu/release/rustzcash.lib
+$(package)_library_file=target/x86_64-pc-windows-gnu/release/librustzcash.a
 else
 $(package)_library_file=target/release/librustzcash.a
 endif

--- a/depends/packages/rust.mk
+++ b/depends/packages/rust.mk
@@ -1,13 +1,18 @@
 package=rust
-$(package)_version=1.32.0
+$(package)_version=1.69.0
 $(package)_download_path=https://static.rust-lang.org/dist
 
 $(package)_file_name_linux=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
-$(package)_sha256_hash_linux=e024698320d76b74daf0e6e71be3681a1e7923122e3ebd03673fcac3ecc23810
+$(package)_sha256_hash_linux=2ca4a306047c0b8b4029c382910fcbc895badc29680e0332c9df990fd1c70d4f
 $(package)_file_name_darwin=rust-$($(package)_version)-x86_64-apple-darwin.tar.gz
-$(package)_sha256_hash_darwin=f0dfba507192f9b5c330b5984ba71d57d434475f3d62bd44a39201e36fa76304
+$(package)_sha256_hash_darwin=9818dab2c3726d63dfbfde12c9273e62e484ef6d6f6e05a6431a3e089c335454
 $(package)_file_name_mingw32=rust-$($(package)_version)-x86_64-pc-windows-gnu.tar.gz
-$(package)_sha256_hash_mingw32=358e1435347c67dbf33aa9cad6fe501a833d6633ed5d5aa1863d5dffa0349be9
+$(package)_sha256_hash_mingw32=9a2a887defb9d0e0aa48fd54237b583a693a2565420b4d90efd0740c0fe69b0d
+
+define $(package)_set_vars
+$(package)_stage_opts=--disable-ldconfig
+$(package)_stage_build_opts=--without=rust-docs-json-preview,rust-docs
+endef
 
 ifeq ($(build_os),darwin)
 $(package)_file_name=$($(package)_file_name_darwin)
@@ -41,12 +46,12 @@ define $(package)_extract_cmds
 endef
 
 define $(package)_stage_cmds
-  ./install.sh --destdir=$($(package)_staging_dir) --prefix=$(host_prefix)/native --disable-ldconfig --without=rust-docs && \
+  ./install.sh --destdir=$($(package)_staging_dir) --prefix=$(host_prefix)/native $($(package)_stage_opts) $($(package)_stage_build_opts) && \
   cp -r ../mingw32/rust-std-x86_64-pc-windows-gnu/lib/rustlib/x86_64-pc-windows-gnu $($(package)_staging_dir)$(host_prefix)/native/lib/rustlib
 endef
 else
 
 define $(package)_stage_cmds
-  ./install.sh --destdir=$($(package)_staging_dir) --prefix=$(host_prefix)/native --disable-ldconfig --without=rust-docs
+  ./install.sh --destdir=$($(package)_staging_dir) --prefix=$(host_prefix)/native $($(package)_stage_opts) $($(package)_stage_build_opts)
 endef
 endif

--- a/zcutil/build-mac-dtest.sh
+++ b/zcutil/build-mac-dtest.sh
@@ -57,7 +57,7 @@ make "$@" -C ./depends/ V=1 NO_QT=1 NO_PROTON=1
 ./autogen.sh
 
 CPPFLAGS="-I$PREFIX/include -arch x86_64 -DTESTMODE" LDFLAGS="-L$PREFIX/lib -arch x86_64 -Wl,-no_pie" \
-CXXFLAGS="-arch x86_64 -I/usr/local/Cellar/gcc\@8/8.3.0/include/c++/8.3.0/ -I$PREFIX/include -fwrapv -fno-strict-aliasing -Wno-builtin-declaration-mismatch -Werror -Wno-error=attributes -g -Wl,-undefined -Wl,dynamic_lookup" \
+CXXFLAGS="-arch x86_64 -I/usr/local/Cellar/gcc\@8/8.3.0/include/c++/8.3.0/ -I$PREFIX/include -fwrapv -fno-strict-aliasing -Wno-deprecated-declarations -Wno-builtin-declaration-mismatch -Werror -Wno-error=attributes -g -Wl,-undefined -Wl,dynamic_lookup" \
 ./configure --prefix="${PREFIX}" --with-gui=no "$HARDENING_ARG" "$LCOV_ARG" "$DEBUGGING_ARG"
 
 make "$@" NO_GTEST=1 STATIC=1

--- a/zcutil/build-mac.sh
+++ b/zcutil/build-mac.sh
@@ -57,7 +57,7 @@ make "$@" -C ./depends/ V=1 NO_QT=1 NO_PROTON=1
 ./autogen.sh
 
 CPPFLAGS="-I$PREFIX/include -arch x86_64" LDFLAGS="-L$PREFIX/lib -arch x86_64 -Wl,-no_pie" \
-CXXFLAGS="-arch x86_64 -I/usr/local/Cellar/gcc\@8/8.3.0/include/c++/8.3.0/ -I$PREFIX/include -fwrapv -fno-strict-aliasing -Wno-builtin-declaration-mismatch -Werror -Wno-error=attributes -g -Wl,-undefined -Wl,dynamic_lookup" \
+CXXFLAGS="-arch x86_64 -I/usr/local/Cellar/gcc\@8/8.3.0/include/c++/8.3.0/ -I$PREFIX/include -fwrapv -fno-strict-aliasing -Wno-deprecated-declarations -Wno-builtin-declaration-mismatch -Werror -Wno-error=attributes -g -Wl,-undefined -Wl,dynamic_lookup" \
 ./configure --prefix="${PREFIX}" --with-gui=no "$HARDENING_ARG" "$LCOV_ARG" "$DEBUGGING_ARG"
 
 make "$@" NO_GTEST=1 STATIC=1


### PR DESCRIPTION
This pull request updates Rust to version 1.69.0. However, we still need to rework the Rust integration, build the crates, and address other related issues. Additionally, this update is expected to resolve the known "not mach-o or llvm bitcode file" issue on MacOS native builds, as described here: https://github.com/KomodoPlatform/komodo/pull/594#issuecomment-1770050716. Please refrain from merging this pull request until all tests, including a sync from scratch and sapling crypto, have been completed.

Furthermore, we have the opportunity to address the warnings that arise during the build of Rust crates.