### PR TITLE
temp disable CC and basic RPC jobs in workflows

### DIFF
--- a/.github/workflows/komodo_linux_ci.yml
+++ b/.github/workflows/komodo_linux_ci.yml
@@ -47,6 +47,7 @@ jobs:
           path: ./komodo-linux.tar.gz
 
   linux-test-dice-token-reards-faucet-cc:
+    if: ${{ false }}
 
     name: Test (Linux/Dice, Token, Faucet, Rewards)
     runs-on: ubuntu-latest
@@ -83,6 +84,7 @@ jobs:
           cd qa/pytest_komodo
           ./ci_setup.sh "cc_modules/test_dice.py cc_modules/test_faucet.py cc_modules/test_token.py cc_modules/test_rewards.py"
   linux-test-oracles:
+    if: ${{ false }}
 
     name: Test (Linux/OraclesCC)
     runs-on: ubuntu-latest
@@ -119,6 +121,7 @@ jobs:
           cd qa/pytest_komodo
           ./ci_setup.sh cc_modules/test_oracles.py
   linux-test-baserpc:
+    if: ${{ false }}
 
     name: Test (Linux/BasicRPC)
     runs-on: ubuntu-latest
@@ -155,6 +158,7 @@ jobs:
           cd qa/pytest_komodo
           ./ci_setup.sh basic
   linux-test-channels:
+    if: ${{ false }}
 
     name: Test (Linux/ChannelsCC)
     runs-on: ubuntu-latest
@@ -191,6 +195,7 @@ jobs:
           cd qa/pytest_komodo
           ./ci_setup.sh cc_modules/test_channels.py
   linux-test-heir:
+    if: ${{ false }}
 
     name: Test (Linux/HeirCC)
     runs-on: ubuntu-latest

--- a/.github/workflows/komodo_mac_ci.yml
+++ b/.github/workflows/komodo_mac_ci.yml
@@ -56,6 +56,7 @@ jobs:
           path: ./komodo-macos.tar.gz
 
   macos-test-dice-token-reards-faucet-cc:
+    if: ${{ false }}
 
     name: Test (MacOS/Dice, Token, Faucet, Rewards)
     runs-on: macos-latest
@@ -85,6 +86,7 @@ jobs:
           ./ci_setup.sh "cc_modules/test_dice.py cc_modules/test_faucet.py cc_modules/test_token.py cc_modules/test_rewards.py"
 
   macos-test-oracles:
+    if: ${{ false }}
 
     name: Test (macos/OraclesCC)
     runs-on: macos-latest
@@ -113,6 +115,7 @@ jobs:
           ./ci_setup.sh cc_modules/test_oracles.py
 
   macos-test-baserpc:
+    if: ${{ false }}
 
     name: Test (macos/BasicRPC)
     runs-on: macos-latest
@@ -141,6 +144,7 @@ jobs:
           ./ci_setup.sh basic
 
   macos-test-channels:
+    if: ${{ false }}
 
     name: Test (macos/ChannelsCC)
     runs-on: macos-latest
@@ -169,6 +173,7 @@ jobs:
           ./ci_setup.sh cc_modules/test_channels.py
 
   macos-test-heir:
+    if: ${{ false }}
 
     name: Test (macos/HeirCC)
     runs-on: macos-latest

--- a/.github/workflows/komodo_win_ci.yml
+++ b/.github/workflows/komodo_win_ci.yml
@@ -73,6 +73,7 @@ jobs:
         path: ./komodod_win.zip
 
   windows-test-baserpc:
+    if: ${{ false }}
 
     name: Test (Win/BasicRPC)
     needs: windows-build
@@ -103,6 +104,7 @@ jobs:
           cd qa\pytest_komodo
           start_ci.bat basic
   windows-test-dice-faucet-tok-rewCC:
+    if: ${{ false }}
 
     name: Test (Win/Dice Faucet Token Rewards)
     runs-on: windows-latest
@@ -133,6 +135,7 @@ jobs:
           cd qa\pytest_komodo
           start_ci.bat cc_modules\test_dice.py cc_modules\test_faucet.py cc_modules\test_token.py cc_modules\test_rewards.py
   windows-test-oracles-cc:
+    if: ${{ false }}
 
     name: Test (Win/OraclesCC)
     runs-on: windows-latest
@@ -163,6 +166,7 @@ jobs:
           cd qa\pytest_komodo
           start_ci.bat cc_modules\test_oracles.py
   windows-test-heir-cc:
+    if: ${{ false }}
 
     name: Test (Win/HeirCC)
     runs-on: windows-latest
@@ -193,6 +197,7 @@ jobs:
           cd qa\pytest_komodo
           start_ci.bat cc_modules\test_heir.py
   windows-test-channels-cc:
+    if: ${{ false }}
 
     name: Test (Win/ChannelsCC)
     runs-on: windows-latest


### PR DESCRIPTION
as the bootstrap_url (https://sirseven.me/share/bootstrap.tar.gz) is no more accessible we will temp disable these jobs, until revise/rethink needed steps (mean, CC is kind of EOL, do we still need these tests here?) and re-create chains, if needed.