### PR TITLE
update dockerfiles

### DIFF
--- a/.github/workflows/komodo_linux_ci.yml
+++ b/.github/workflows/komodo_linux_ci.yml
@@ -10,7 +10,7 @@ jobs:
 
   linux-build:
     name: Linux Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
     if: ${{ false }}
 
     name: Test (Linux/Dice, Token, Faucet, Rewards)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: linux-build
 
     steps:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ false }}
 
     name: Test (Linux/OraclesCC)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: linux-build
 
     steps:
@@ -124,7 +124,7 @@ jobs:
     if: ${{ false }}
 
     name: Test (Linux/BasicRPC)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: linux-build
 
     steps:
@@ -161,7 +161,7 @@ jobs:
     if: ${{ false }}
 
     name: Test (Linux/ChannelsCC)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: linux-build
 
     steps:
@@ -198,7 +198,7 @@ jobs:
     if: ${{ false }}
 
     name: Test (Linux/HeirCC)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: linux-build
 
     steps:

--- a/.github/workflows/komodo_win_ci.yml
+++ b/.github/workflows/komodo_win_ci.yml
@@ -11,7 +11,7 @@ jobs:
   windows-build:
 
     name: Win Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/komodo_win_ci.yml
+++ b/.github/workflows/komodo_win_ci.yml
@@ -11,7 +11,7 @@ jobs:
   windows-build:
 
     name: Win Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/komodod_cd.yml
+++ b/.github/workflows/komodod_cd.yml
@@ -81,6 +81,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install deps (macOS)
         run: |
+          rm '/usr/local/bin/2to3'
+          brew unlink node
           brew update
           brew upgrade || true
           brew tap discoteq/discoteq; brew install flock

--- a/.github/workflows/komodod_cd.yml
+++ b/.github/workflows/komodod_cd.yml
@@ -106,7 +106,7 @@ jobs:
 
   windows-build:
     name: Windows Build (mingw)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/komodod_cd.yml
+++ b/.github/workflows/komodod_cd.yml
@@ -104,7 +104,7 @@ jobs:
 
   windows-build:
     name: Windows Build (mingw)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -138,7 +138,7 @@ jobs:
 
   publish-release:
       name: Publishing CD releases
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
       needs: [linux-build, osx-build, windows-build]
       steps:
         - name: Download komodo-linux.zip

--- a/.github/workflows/komodod_cd.yml
+++ b/.github/workflows/komodod_cd.yml
@@ -33,19 +33,22 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install deps (Linux)
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
+          sudo apt-get update
+          sudo apt-get install software-properties-common -y
           sudo apt-get update  # prevents repo404 errors on apt-remove below
           sudo apt-get remove php* msodbcsql17 mysql* powershell dotn*
-          sudo apt-get update
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update -y
           sudo ACCEPT_EULA=Y apt-get upgrade -y
-          sudo apt-get install -q \
-                 curl \
-                 python3 \
-                 python3-dev \
-                 python3-setuptools \
-                 python3-pip \
-                 libcurl4-openssl-dev \
-                 libssl-dev -y
+          sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool \
+                              libncurses-dev unzip wget bsdmainutils automake libboost-all-dev libssl-dev \
+                              libprotobuf-dev protobuf-compiler libqrencode-dev libdb++-dev ntp ntpdate nano \
+                              curl libevent-dev libcurl4-gnutls-dev cmake clang \
+                              libsodium-dev ncurses-dev git python3 python3-zmq zlib1g-dev libstdc++6 -y
+          strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
       - name: Build (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -64,12 +67,12 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build container
-        run: docker build -f Dockerfile.release -t komodoofficial/komodo:cd_release_${{ steps.shortify_commit.outputs.sha_short }}_${{ steps.extract_branch.outputs.branch }} .
+        run: docker build -f Dockerfile.release -t ${{ secrets.DOCKER_ORG }}/komodo:cd_release_${{ steps.shortify_commit.outputs.sha_short }}_${{ steps.extract_branch.outputs.branch }} .
 
       - name: Push to docker hub
         uses: actions-hub/docker@master
         with:
-          args: push komodoofficial/komodo:cd_release_${{ steps.shortify_commit.outputs.sha_short }}_${{ steps.extract_branch.outputs.branch }}
+          args: push ${{ secrets.DOCKER_ORG }}/komodo:cd_release_${{ steps.shortify_commit.outputs.sha_short }}_${{ steps.extract_branch.outputs.branch }}
 
   osx-build:
     name: OSX Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:16.04
-MAINTAINER Mihail Fedorov <kolo@komodoplatform.com>
+FROM ubuntu:20.04
+LABEL maintainer="smk762 <smk@komodoplatform.com>"
 
 RUN apt-get -y update && \
     apt-get -y upgrade && \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,8 +1,18 @@
 FROM ubuntu:20.04
-RUN \ 
-    apt-get update &&\
-    apt-get install -y libgomp1
-CMD mkdir /komodo
+LABEL maintainer="smk@komodoplatform.com"
+RUN \
+    export ACCEPT_EULA=Y && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install software-properties-common -y && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
+    apt-get install libgomp1 libstdc++6 binutils -y
+RUN mkdir /komodo
 WORKDIR /komodo
 COPY src/komodod src/komodo-cli ./
+RUN ln -sf /komodo/komodod /usr/bin/komodod && \
+    ln -sf /komodo/komodo-cli /usr/bin/komodo-cli
 CMD ./komodod


### PR DESCRIPTION
- Adds `DOCKER_ORG` actions secret to make dockerhub uploads in forks easier.
- Uses ubuntu-20.4 runner to avoid GLIBC errors
- confirmed working with NN docker repo