### PR TITLE
build: fix build on xenial (16.04)

### DIFF
--- a/src/cryptoconditions/Makefile.am
+++ b/src/cryptoconditions/Makefile.am
@@ -65,7 +65,7 @@ libcryptoconditions_core_a_SOURCES = \
 	src/asn/per_decoder.c \
 	src/asn/per_encoder.c \
 	src/asn/per_opentype.c
-libcryptoconditions_core_a_CPPFLAGS=-I. -I./src/include -I./src/asn
+libcryptoconditions_core_a_CPPFLAGS=-I. -I./src/include -I./src/asn -fPIC
 
 test:
 	bash -c '[ -d .env ] || virtualenv .env -p python3'


### PR DESCRIPTION
This should resolve the build issue on `Xenial (Ubuntu 16.04)`. Officially, we do not support it as it has reached its End of Life (EOL). However, since building under Xenial is still possible, it might be a good idea to fix it. Moreover, binaries built under Xenial should also function on higher versions of Ubuntu / Linux distributions with a higher LIBC version.

Without -fPIC for libcryptoconditions_core.a build will end with error below on Xenial:

```
/usr/bin/ld: cryptoconditions/libcryptoconditions_core.a(libcryptoconditions_core_a-cryptoconditions.o): relocation R_X86_64_32 against `.text' can not be used when making a shared object; recompile with -fPIC
cryptoconditions/libcryptoconditions_core.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
```