### PR TITLE
Allow on demand publishing to dockerhub

### DIFF
--- a/.github/workflows/komodod_cd.yml
+++ b/.github/workflows/komodod_cd.yml
@@ -2,7 +2,6 @@
 
 name: Komodo CD test releases
 
-
 on:
   push:
     branches:
@@ -10,6 +9,7 @@ on:
     - dev
     - research
     - master
+  workflow_dispatch:
 
 jobs:
 
@@ -76,6 +76,7 @@ jobs:
 
   osx-build:
     name: OSX Build
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -106,6 +107,7 @@ jobs:
 
   windows-build:
     name: Windows Build (mingw)
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -140,6 +142,7 @@ jobs:
 
   publish-release:
       name: Publishing CD releases
+      if: ${{ github.event_name != 'workflow_dispatch' }}
       runs-on: ubuntu-20.04
       needs: [linux-build, osx-build, windows-build]
       steps:


### PR DESCRIPTION
Once merged to master, this will allow an "on demand" workflow trigger button which will build the linux binary and upload it to dockerhub for any future branch, which can then be used for testing in a dockerised environment (e.g. via https://github.com/smk762/qa_postman_tests).

When the workflow is manually triggered from the workflow dispatch button, it will not process  the build steps for MacOS/Windows, and skip the release binary upload steps.

Example from my fork:
![image](https://github.com/KomodoPlatform/komodo/assets/35845239/73a41b93-2ced-4e2a-93d4-3fb6a2c6b6aa)
