### PR TITLE
mac build: fix boost 1.72 build error with clang 16

### DIFF
--- a/.github/workflows/komodo_mac_ci.yml
+++ b/.github/workflows/komodo_mac_ci.yml
@@ -10,7 +10,7 @@ jobs:
 
   macos-build:
     name: MacOS Build
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     
     steps:
       - uses: actions/checkout@v4

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -4,7 +4,7 @@ $(package)_version=1_72_0
 $(package)_download_path=https://github.com/KomodoPlatform/boost/releases/download/boost-1.72.0-kmd
 $(package)_sha256_hash=59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
-$(package)_patches=fix-Solaris.patch ignore_wnonnull_gcc_11.patch
+$(package)_patches=fix-Solaris.patch ignore_wnonnull_gcc_11.patch range_enums_clang_16.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -30,7 +30,8 @@ endef
 define $(package)_preprocess_cmds
   echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam&& \
   patch -p1 < $($(package)_patch_dir)/fix-Solaris.patch &&\
-  patch -p2 < $($(package)_patch_dir)/ignore_wnonnull_gcc_11.patch
+  patch -p2 < $($(package)_patch_dir)/ignore_wnonnull_gcc_11.patch &&\
+  patch -p2 < $($(package)_patch_dir)/range_enums_clang_16.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/boost/range_enums_clang_16.patch
+++ b/depends/patches/boost/range_enums_clang_16.patch
@@ -1,0 +1,75 @@
+diff --git a/include/boost/numeric/conversion/detail/int_float_mixture.hpp b/include/boost/numeric/conversion/detail/int_float_mixture.hpp
+index 464e527..7690d07 100644
+--- a/include/boost/numeric/conversion/detail/int_float_mixture.hpp
++++ b/include/boost/numeric/conversion/detail/int_float_mixture.hpp
+@@ -16,15 +16,15 @@
+ #include "boost/numeric/conversion/int_float_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'IntFloatMixture'
+-  typedef mpl::integral_c<int_float_mixture_enum, integral_to_integral> int2int_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, integral_to_float>    int2float_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, float_to_integral>    float2int_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, float_to_float>       float2float_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, integral_to_integral> int2int_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, integral_to_float>    int2float_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, float_to_integral>    float2int_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, float_to_float>       float2float_c ;
+ 
+   // Metafunction:
+   //
+diff --git a/include/boost/numeric/conversion/detail/sign_mixture.hpp b/include/boost/numeric/conversion/detail/sign_mixture.hpp
+index c7f9e42..fde1584 100644
+--- a/include/boost/numeric/conversion/detail/sign_mixture.hpp
++++ b/include/boost/numeric/conversion/detail/sign_mixture.hpp
+@@ -16,15 +16,15 @@
+ #include "boost/numeric/conversion/sign_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'SignMixture'
+-  typedef mpl::integral_c<sign_mixture_enum, unsigned_to_unsigned> unsig2unsig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, signed_to_signed>     sig2sig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, signed_to_unsigned>   sig2unsig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, unsigned_to_signed>   unsig2sig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, unsigned_to_unsigned> unsig2unsig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, signed_to_signed>     sig2sig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, signed_to_unsigned>   sig2unsig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, unsigned_to_signed>   unsig2sig_c ;
+ 
+   // Metafunction:
+   //
+diff --git a/include/boost/numeric/conversion/detail/udt_builtin_mixture.hpp b/include/boost/numeric/conversion/detail/udt_builtin_mixture.hpp
+index 36dbc49..a39d29f 100644
+--- a/include/boost/numeric/conversion/detail/udt_builtin_mixture.hpp
++++ b/include/boost/numeric/conversion/detail/udt_builtin_mixture.hpp
+@@ -15,15 +15,15 @@
+ #include "boost/numeric/conversion/udt_builtin_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'UdtMixture'
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, builtin_to_builtin> builtin2builtin_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, builtin_to_udt>     builtin2udt_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, udt_to_builtin>     udt2builtin_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, udt_to_udt>         udt2udt_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, builtin_to_builtin> builtin2builtin_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, builtin_to_udt>     builtin2udt_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, udt_to_builtin>     udt2builtin_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, udt_to_udt>         udt2udt_c ;
+ 
+   // Metafunction:
+   //


### PR DESCRIPTION
error: integer value -1 is outside the valid range of values [0, 3] for this enumeration type

- https://trac.macports.org/ticket/69103
- https://github.com/boostorg/numeric_conversion/commit/50a1eae942effb0a9b90724323ef8f2a67e7984a

**p.s.** Don't merge until tests are completed.