### PR TITLE
enable KIP0003 consensus rule

### DIFF
--- a/src/komodo_bitcoind.cpp
+++ b/src/komodo_bitcoind.cpp
@@ -2057,12 +2057,11 @@ int32_t komodo_checkPOW(int64_t stakeTxValue, int32_t slowflag,CBlock *pblock,in
                                blk.vtx[0].vout[0].nValue <= blockReward &&
                                blk.vtx[0].vout[1].scriptPubKey.IsOpReturn();
 
-        LogPrintf("KIP0003 check for NN: ht.%d, hash.%s - %s\n",
-                  height, blk.GetHash().ToString(),
-                  fKIP0003Checked ? "PASSED!" : "FAILED!");
+        LogPrint("hfnet", "KIP0003 check for NN: ht.%d, hash.%s - %s\n",
+                 height, blk.GetHash().ToString(),
+                 fKIP0003Checked ? "PASSED!" : "FAILED!");
 
-        // Uncomment the following line if you need to return -1 on failure
-        // if (!fKIP0003Checked) return -1;
+        if (!fKIP0003Checked) return -1;
     }
 
     //fprintf(stderr,"komodo_checkPOW possible.%d slowflag.%d ht.%d notaryid.%d failed.%d\n",possible,slowflag,height,notaryid,failed);


### PR DESCRIPTION
The KIP0003 consensus rule was added in the `dev` branch as "logging only", i.e. as disabled. However, in the `patch-s8-prepare-hf-test` branch, which we used for testing on hfnet, it's already enabled
(as seen in [this commit](https://github.com/KomodoPlatform/komodo/commit/783fc1f83144d05a1dc6103d5dae4ef677bf241f)). For the release, we should enable this rule and make the logging optional using the hfnet category.