### PR TITLE
fix linkage on Xenial (16.04)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -369,6 +369,7 @@ libbitcoin_wallet_a_SOURCES = \
 # a static library for cryptoconditions
 libcc_a_SOURCES = cc/cclib.cpp
 libcc_a_CXXFLAGS = -DBUILD_CUSTOMCC -I../secp256k1/include -I../depends/$(shell echo `../depends/config.guess`/include) -I./univalue/include -I./cryptoconditions/include -I./cryptoconditions/src -I./cryptoconditions/src/asn -I. -I./cc
+libcc_a_CPPFLAGS = -fPIC
 # libcc_a_LDFLAGS = -version-info 0:0:0
 
 # crypto primitives library


### PR DESCRIPTION
This PR fixes linkage error below on Xenial:
```
/usr/bin/ld: libcc.a(libcc_a-cclib.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a shared object; recompile with -fPIC
libcc.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
Makefile:2305: recipe for target 'komodod' failed
make[2]: *** [komodod] Error 1
```