### PR TITLE
fix old and new gleec checkpoints

### DIFF
--- a/.github/workflows/komodo_linux_ci.yml
+++ b/.github/workflows/komodo_linux_ci.yml
@@ -41,7 +41,7 @@ jobs:
           CONFIGURE_FLAGS='CPPFLAGS=-DTESTMODE' ./zcutil/build.sh -j$(nproc)
           tar -czvf komodo-linux.tar.gz src/komodod src/komodo-cli
       - name: Upload komodo-linux.tar.gz as artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: komodo-linux
           path: ./komodo-linux.tar.gz
@@ -71,7 +71,7 @@ jobs:
           python3 -m pip install pytest wget jsonschema
           python3 -m pip install -Iv https://github.com/KomodoPlatform/slick-bitcoinrpc/archive/refs/tags/0.1.4.tar.gz
       - name: Download komodo-linux.tar.gz
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: komodo-linux
 
@@ -108,7 +108,7 @@ jobs:
           python3 -m pip install pytest wget jsonschema
           python3 -m pip install -Iv https://github.com/KomodoPlatform/slick-bitcoinrpc/archive/refs/tags/0.1.4.tar.gz
       - name: Download komodo-linux.tar.gz
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: komodo-linux
 
@@ -145,7 +145,7 @@ jobs:
           python3 -m pip install pytest wget jsonschema
           python3 -m pip install -Iv https://github.com/KomodoPlatform/slick-bitcoinrpc/archive/refs/tags/0.1.4.tar.gz
       - name: Download komodo-linux.tar.gz
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: komodo-linux
 
@@ -182,7 +182,7 @@ jobs:
           python3 -m pip install pytest wget jsonschema
           python3 -m pip install -Iv https://github.com/KomodoPlatform/slick-bitcoinrpc/archive/refs/tags/0.1.4.tar.gz
       - name: Download komodo-linux.tar.gz
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: komodo-linux
 
@@ -219,7 +219,7 @@ jobs:
           python3 -m pip install pytest wget jsonschema
           python3 -m pip install -Iv https://github.com/KomodoPlatform/slick-bitcoinrpc/archive/refs/tags/0.1.4.tar.gz
       - name: Download komodo-linux.tar.gz
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: komodo-linux
 

--- a/.github/workflows/komodo_mac_ci.yml
+++ b/.github/workflows/komodo_mac_ci.yml
@@ -50,7 +50,7 @@ jobs:
         #   DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
 
       - name: Upload komodo-macos.tar.gz as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: komodo-macos
           path: |
@@ -73,7 +73,7 @@ jobs:
           python3 -m pip install slick-bitcoinrpc pytest wget jsonschema
 
       - name: Download komodo-macos.tar.gz
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: komodo-macos
 
@@ -102,7 +102,7 @@ jobs:
           python3 -m pip install setuptools wheel
           python3 -m pip install slick-bitcoinrpc pytest wget jsonschema
       - name: Download komodo-macos.tar.gz
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: komodo-macos
 
@@ -131,7 +131,7 @@ jobs:
           python3 -m pip install setuptools wheel
           python3 -m pip install slick-bitcoinrpc pytest wget jsonschema
       - name: Download komodo-macos.tar.gz
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: komodo-macos
 
@@ -160,7 +160,7 @@ jobs:
           python3 -m pip install setuptools wheel
           python3 -m pip install slick-bitcoinrpc pytest wget jsonschema
       - name: Download komodo-macos.tar.gz
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: komodo-macos
 
@@ -189,7 +189,7 @@ jobs:
           python3 -m pip install setuptools wheel
           python3 -m pip install slick-bitcoinrpc pytest wget jsonschema
       - name: Download komodo-macos.tar.gz
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: komodo-macos
 

--- a/.github/workflows/komodo_win_ci.yml
+++ b/.github/workflows/komodo_win_ci.yml
@@ -67,7 +67,7 @@ jobs:
         ./zcutil/build-win-dtest.sh -j$(nproc)
         zip --junk-paths komodod_win src/komodod.exe src/komodo-cli.exe
     - name: Upload komodod.exe as artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: komodod_win
         path: ./komodod_win.zip
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download komodo_win.zip
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: komodod_win
 
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download komodo_win.zip
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: komodod_win
 
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download komodo_win.zip
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: komodod_win
 
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download komodo_win.zip
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: komodod_win
 
@@ -207,7 +207,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download komodo_win.zip
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: komodod_win
 

--- a/.github/workflows/komodod_cd.yml
+++ b/.github/workflows/komodod_cd.yml
@@ -55,7 +55,7 @@ jobs:
           ./zcutil/build.sh -j$(nproc)
           zip --junk-paths komodo-linux src/komodod src/komodo-cli
       - name: Upload komodo-linux.zip as artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: komodo-linux
           path: ./komodo-linux.zip
@@ -112,7 +112,7 @@ jobs:
           zip --junk-paths komodo-osx src/komodod src/komodo-cli
 
       - name: Upload komodo-osx.zip as artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: komodo-osx
           path: ./komodo-osx.zip
@@ -147,7 +147,7 @@ jobs:
           ./zcutil/build-win.sh -j$(nproc)
           zip --junk-paths komodo-win src/komodod.exe src/komodo-cli.exe
       - name: Upload komodo-win.zip as artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: komodo-win
           path: ./komodo-win.zip      
@@ -159,15 +159,15 @@ jobs:
       needs: [linux-build, osx-build, windows-build]
       steps:
         - name: Download komodo-linux.zip
-          uses: actions/download-artifact@v1
+          uses: actions/download-artifact@v3
           with:
             name: komodo-linux  
         - name: Download komodo-osx.zip
-          uses: actions/download-artifact@v1
+          uses: actions/download-artifact@v3
           with:
             name: komodo-osx
         - name: Download komodo-win.zip
-          uses: actions/download-artifact@v1
+          uses: actions/download-artifact@v3
           with:
             name: komodo-win
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -733,8 +733,8 @@ const CChainParams::CCheckpointData GetACCheckPoints()
                 2777            // * estimated number of transactions per day after checkpoint
                                 //   total number of tx / (checkpoint block height / (24 * 24))
                 };
-    /* GLEEC */
-    const CChainParams::CCheckpointData checkpointDataGLEEC = {
+    /* old GLEEC */
+    const CChainParams::CCheckpointData checkpointDataGLEECOld = {
                 boost::assign::map_list_of
                 (	0,	Params(CBaseChainParams::MAIN).GetConsensus().hashGenesisBlock)
                 (	97090,	uint256S("0x00008075af58a2d0a52ac480b31a74beb6b2f1261ae2984d29b8429ee4d86f9a"))
@@ -941,13 +941,20 @@ const CChainParams::CCheckpointData GetACCheckPoints()
         ("CCL", checkpointDataCCL)
         ("CLC", checkpointDataCLC)
         ("DOC", checkpointDataDOC)
-        ("GLEEC", checkpointDataGLEEC)
         ("ILN", checkpointDataILN)
         ("KOIN", checkpointDataKOIN)
         ("MARTY", checkpointDataMARTY)
         ("NINJA", checkpointDataNINJA)
         ("PIRATE", checkpointDataPIRATE)
         ("SUPERNET", checkpointDataSUPERNET);
+
+    // Check for GLEEC chain with old and new parameters
+    if (chainName.ToString() == "GLEEC") {
+        if (ASSETCHAINS_SUPPLY == 210000000 && ASSETCHAINS_STAKED == 100) { /* old GLEEC */
+            return checkpointDataGLEECOld;
+        }
+        return checkpointDataDefault; // TODO: return new checkpoints, when we will have enough data
+    }
 
     auto it = mapACCheckpointsData.find(chainName.ToString());
     if (it != mapACCheckpointsData.end()) {

--- a/src/wallet-utility.cpp
+++ b/src/wallet-utility.cpp
@@ -13,6 +13,7 @@
 #include "assetchain.h"
 assetchain chainName;
 
+/*
 int64_t MAX_MONEY = 200000000 * 100000000LL;
 uint64_t ASSETCHAINS_SUPPLY;
 uint16_t BITCOIND_RPCPORT = 7771;
@@ -26,6 +27,7 @@ int32_t ASSETCHAINS_SAPLING = 227520;
 bool IS_KOMODO_TESTNODE = false;
 
 unsigned int MAX_BLOCK_SIGOPS = 20000;
+*/
 
 void show_help()
 {


### PR DESCRIPTION
There was an error with relaying and propagating transactions on the `new GLEEC` chain. Since the `old GLEEC` chain was protected with checkpoints and the new chain shares the same ticker, the node assumed that Initial Block Download (IBD) hadn’t finished and therefore didn’t accept `tx` p2p messages. The system wasn’t designed to handle two different chains with the same name. This PR resolves the issue. In the future, I recommend deprecating the old GLEEC chain and avoiding such conflicts to prevent similar issues.






