### PR TITLE
libsodium: don't update config.sub, congig.guess from git.savannah.gnu.org

### DIFF
--- a/depends/packages/libsodium.mk
+++ b/depends/packages/libsodium.mk
@@ -7,7 +7,6 @@ $(package)_dependencies=
 $(package)_config_opts=
 
 define $(package)_set_vars
-  $(package)_build_env=DO_NOT_UPDATE_CONFIG_SCRIPTS=1
   ifeq ($(build_os),darwin)
   $(package)_build_env+=MACOSX_DEPLOYMENT_TARGET="$(OSX_MIN_VERSION)"
   $(package)_cc=clang
@@ -16,7 +15,7 @@ define $(package)_set_vars
 endef
 
 define $(package)_preprocess_cmds
-  cd $($(package)_build_subdir); ./autogen.sh
+  cd $($(package)_build_subdir); DO_NOT_UPDATE_CONFIG_SCRIPTS=1 ./autogen.sh
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
As of August 30, 2024, `git.savannah.gnu.org` returned a 502 error when trying to download `config.guess` and `config.sub`. For example, attempting to download [this link](https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD) returned a 502 error. As a result, all scripts, workflows, etc., that relied on getting fresh versions of `config.{sub,guess}` from `git.savannah.gnu.org` are failing. To prevent this, we disabled updating to the fresh versions of these scripts.

- https://github.com/DeckerSU/KomodoOcean/commit/4a298288c2f66c8fc1abd27aa78de52c1d7c5a70
- https://github.com/KomodoPlatform/komodo/pull/633