### PR TITLE
GLEEC_OLD: exception to fix following the notarizations

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -951,6 +951,9 @@ const CChainParams::CCheckpointData GetACCheckPoints()
     // Check for GLEEC chain with old and new parameters
     if (chainName.ToString() == "GLEEC") {
         if (ASSETCHAINS_SUPPLY == 210000000 && ASSETCHAINS_STAKED == 100) { /* old GLEEC */
+            ClearDatadirCache();
+            chainName = assetchain("GLEEC_OLD");  /* exception to fix following notarizations,
+            we shouldn't do things like that! */
             return checkpointDataGLEECOld;
         }
         return checkpointDataDefault; // TODO: return new checkpoints, when we will have enough data

--- a/src/komodo_utils.cpp
+++ b/src/komodo_utils.cpp
@@ -1006,6 +1006,15 @@ void komodo_args(char *argv0)
     uint16_t nonz=0; // keep track of # CCs enabled
     int32_t extralen = 0;
 
+    // prevent start old GLEEC chain without datadir specify
+    if (GetArg("-ac_name","") == "GLEEC" && GetArg("-ac_supply",10) == 210000000 && GetArg("-ac_staked",0) == 100) {
+        if (mapArgs.count("-datadir") == 0) {
+            const std::string strOldGLEECStartUpError = "It's mandatory to launch old GLEEC chain with -datadir specify!";
+            std::cerr << strOldGLEECStartUpError << std::endl;
+            throw std::runtime_error(strOldGLEECStartUpError);
+        }
+    }
+
     const std::string ntz_dest_path = GetArg("-notary", "");
     IS_KOMODO_NOTARY = ntz_dest_path == "" ? 0 : 1;
 

--- a/src/komodo_utils.cpp
+++ b/src/komodo_utils.cpp
@@ -1006,10 +1006,10 @@ void komodo_args(char *argv0)
     uint16_t nonz=0; // keep track of # CCs enabled
     int32_t extralen = 0;
 
-    // prevent start old GLEEC chain without datadir specify
+    // prevent starting old GLEEC chain without datadir specified
     if (GetArg("-ac_name","") == "GLEEC" && GetArg("-ac_supply",10) == 210000000 && GetArg("-ac_staked",0) == 100) {
         if (mapArgs.count("-datadir") == 0) {
-            const std::string strOldGLEECStartUpError = "It's mandatory to launch old GLEEC chain with -datadir specify!";
+            const std::string strOldGLEECStartUpError = "It's mandatory to launch old GLEEC chain with -datadir specified!";
             std::cerr << strOldGLEECStartUpError << std::endl;
             throw std::runtime_error(strOldGLEECStartUpError);
         }


### PR DESCRIPTION
This update should fix the notarization issue with the old GLEEC chain. After applying the fix, the output of the `getinfo` RPC call should look something like this:
```bash
komodo-cli -ac_name=GLEEC -datadir=/home/builder/.komodo/GLEEC_OLD getinfo | jq .
```

```json
{
  "version": 90000,
  "protocolversion": 170013,
  "KMDversion": "0.9.0",
  "synced": true,
  "notarized": 974444,
  "prevMoMheight": 974444,
  "notarizedhash": "0958f1dd625d89d5749b698cbf7e57eb294dd1916d828d60fbf9de9dfd9053e4",
  "notarizedtxid": "7fdc3a5452baef619452408cc31fac86de468755380914d7f172dc78b7702ac8",
  "notarizedtxid_height": "mempool",
  "KMDnotarized_height": 0,
  "notarized_confirms": 0,
  "walletversion": 60000,
  "balance": 0,
  "blocks": 974458,
  "longestchain": 974458,
  "tiptime": 1728914950,
  "difficulty": 1,
  "keypoololdest": 1728668685,
  "keypoolsize": 101,
  "paytxfee": 0,
  "sapling": 61,
  "timeoffset": 0,
  "connections": 16,
  "proxy": "",
  "testnet": false,
  "relayfee": 1e-06,
  "errors": "",
  "name": "GLEEC_OLD",
  "p2pport": 23225,
  "rpcport": 23226,
  "magic": 1824725725,
  "premine": 210000000,
  "staked": 100
}
```
The fix changes the chain name (ticker) "at runtime," allowing us to keep the existing chain parameters and magic. Normally, we wouldn’t do something like this, but for the old GLEEC chain, we will make an exception. Additionally, the user should create a symlink for the `.conf` file like this:

```bash
ln -s -f $HOME/.komodo/GLEEC_OLD/GLEEC.conf $HOME/.komodo/GLEEC_OLD/GLEEC_OLD.conf
```
The daemon should be launched with `-datadir=$HOME/.komodo/GLEEC_OLD`, and the data directory should contain `GLEEC.conf` along with a symlink to it named `GLEEC_OLD.conf`.