### PR TITLE
ci/cd: update runner image ubuntu-20.04 -> ubuntu-22.04

### DIFF
--- a/.github/workflows/komodo_linux_ci.yml
+++ b/.github/workflows/komodo_linux_ci.yml
@@ -10,7 +10,7 @@ jobs:
 
   linux-build:
     name: Linux Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
     if: ${{ false }}
 
     name: Test (Linux/Dice, Token, Faucet, Rewards)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: linux-build
 
     steps:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ false }}
 
     name: Test (Linux/OraclesCC)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: linux-build
 
     steps:
@@ -124,7 +124,7 @@ jobs:
     if: ${{ false }}
 
     name: Test (Linux/BasicRPC)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: linux-build
 
     steps:
@@ -161,7 +161,7 @@ jobs:
     if: ${{ false }}
 
     name: Test (Linux/ChannelsCC)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: linux-build
 
     steps:
@@ -198,7 +198,7 @@ jobs:
     if: ${{ false }}
 
     name: Test (Linux/HeirCC)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: linux-build
 
     steps:

--- a/.github/workflows/komodod_cd.yml
+++ b/.github/workflows/komodod_cd.yml
@@ -16,7 +16,7 @@ jobs:
   linux-build:
     name: Linux Build
     # using there as old release as possible with GHA worker to provide better compatibility
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Extract branch name
@@ -155,7 +155,7 @@ jobs:
   publish-release:
       name: Publishing CD releases
       if: ${{ github.event_name != 'workflow_dispatch' }}
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
       needs: [linux-build, osx-build, windows-build]
       steps:
         - name: Download komodo-linux.zip


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.