### PR TITLE
Fix MacOS CI/CD

### DIFF
--- a/.github/workflows/komodo_mac_ci.yml
+++ b/.github/workflows/komodo_mac_ci.yml
@@ -44,6 +44,8 @@ jobs:
       # flag for some CC tests transactions - so DO NOT USE THIS CI ARTIFACTS IN PRODUCTION!!!
       - name: Build (macOS)
         run: |
+          # Ensure depends can fetch ccache archive on macOS runners
+          export PRIORITY_DOWNLOAD_PATH="https://github.com/ccache/ccache/releases/download/v3.7.4"
           ./zcutil/build-mac-dtest.sh -j4
           gtar -czvf komodo-macos.tar.gz src/komodod src/komodo-cli src/wallet-utility src/komodo-tx
         # env:

--- a/.github/workflows/komodod_cd.yml
+++ b/.github/workflows/komodod_cd.yml
@@ -108,6 +108,8 @@ jobs:
 
       - name: Build (macOS)
         run: |
+          # Ensure depends can fetch ccache archive on macOS runners
+          export PRIORITY_DOWNLOAD_PATH="https://github.com/ccache/ccache/releases/download/v3.7.4"
           ./zcutil/build-mac.sh -j4
           zip --junk-paths komodo-osx src/komodod src/komodo-cli
 


### PR DESCRIPTION
Error seen in recent workflow runs:
- https://github.com/KomodoPlatform/komodo/actions/runs/16345694045/job/46178666342?pr=644
- https://github.com/KomodoPlatform/komodo/actions/runs/16345694970/job/46178668821?pr=644

```bash
curl: (3) URL rejected: No host part in the URL
shasum: /Users/runner/work/komodo/komodo/depends/work/download/native_ccache-3.7.4/ccache-3.7.4.tar.xz.temp: No such file or directory
shasum: WARNING: 1 listed file could not be read
/Users/runner/work/komodo/komodo/depends/work/download/native_ccache-3.7.4/ccache-3.7.4.tar.xz.temp: FAILED open or read
make: *** [/Users/runner/work/komodo/komodo/depends/sources/download-stamps/.stamp_fetched-native_ccache-ccache-3.7.4.tar.xz.hash] Error 1
```

Consulting o3 suggested this fix .
<img width="550" height="457" alt="image" src="https://github.com/user-attachments/assets/035bf2b5-5bac-4f8f-b14c-1d7f6b91baa0" />
