### PR TITLE
Strip debug info from Linux and Windows release builds

### DIFF
--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -1,7 +1,7 @@
 linux_CFLAGS=-pipe
 linux_CXXFLAGS=$(linux_CFLAGS)
 
-linux_release_CFLAGS=-g -O2
+linux_release_CFLAGS=-O2
 linux_release_CXXFLAGS=$(linux_release_CFLAGS)
 
 linux_debug_CFLAGS=-g -O0

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -3,7 +3,7 @@ mingw32_CXX=x86_64-w64-mingw32-g++-posix
 mingw32_CFLAGS=-pipe -std=c11
 mingw32_CXXFLAGS=-pipe -std=c++11
 
-mingw32_release_CFLAGS=-g -O2
+mingw32_release_CFLAGS=-O2
 mingw32_release_CXXFLAGS=$(mingw32_CXXFLAGS) $(mingw32_release_CFLAGS)
 
 mingw32_debug_CFLAGS=-g -O0


### PR DESCRIPTION
Remove the `-g` debugging flag from all release build `CFLAGS` on both Linux and Windows (mingw32). Release builds now compile with `-O2` only, preventing debug symbols from being embedded in production binaries. This change reduces executable size and eliminates accidental exposure of debug information.