### PR TITLE
[depends] Fix FALLBACK_DOWNLOAD_PATH

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -5,7 +5,7 @@ BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
 NO_WALLET ?=
 NO_UPNP ?=
-FALLBACK_DOWNLOAD_PATH ?= https://supernet/depends-sources
+FALLBACK_DOWNLOAD_PATH ?= https://download.decker.im/depends-sources
 
 BUILD ?= $(shell ./config.guess)
 HOST ?= $(BUILD)

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -22,8 +22,8 @@ endef
 define fetch_file
 (test -f $$($(1)_source_dir)/$(4) || \
   ( mkdir -p $$($(1)_download_dir) && echo Fetching $(1)... && \
-  ( $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(PRIORITY_DOWNLOAD_PATH)/$(4)" || \
-    $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(2)/$(3)" ) && \
+  ( $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(2)/$(3)" || \
+    $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(FALLBACK_DOWNLOAD_PATH)/$(4)" ) && \
     echo "$(5)  $$($(1)_download_dir)/$(4).temp" > $$($(1)_download_dir)/.$(4).hash && \
     $(build_SHA256SUM) -c $$($(1)_download_dir)/.$(4).hash && \
     mv $$($(1)_download_dir)/$(4).temp $$($(1)_source_dir)/$(4) && \


### PR DESCRIPTION
Fixes the case where build_DOWNLOAD (using curl or wget) fails to download the required package from the default URL specified in depends/packages/%recipe_name%.mk. It will then attempt to download from FALLBACK_DOWNLOAD_PATH. This also resolves the macOS CI/CD error "curl: (3) URL rejected: No host part in the URL" noted here: https://github.com/KomodoPlatform/komodo/pull/652. It appears that newer versions of curl included in the latest GitHub runner image exit with an error when FALLBACK_DOWNLOAD_PATH is not set (due to mixed-up variable names FALLBACK_DOWNLOAD_PATH and PRIORITY_DOWNLOAD_PATH in the Makefile). This should now be fixed.