### PR TITLE
use ubuntu22 image

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL maintainer="smk@komodoplatform.com"
 RUN \
     export ACCEPT_EULA=Y && \


### PR DESCRIPTION
Current output sent to dockerhub is faulty, as the GHA build environment [`runs-on: ubuntu-22.04`](https://github.com/KomodoPlatform/komodo/blob/master/.github/workflows/komodod_cd.yml#L19), but the docker base image was set to run `FROM ubuntu:20.04`.

The result was the following errors on launching the images uploaded to dockerhub 
```
komodo-cli: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by komodo-cli)
komodo-cli: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by komodo-cli)
komodo-cli: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by komodo-cli)
````

By aligning the GHA build env and dockerfile base image, these errors will be avoided.
