### PR TITLE
feat(checkpoints): enable auto checkpoints for BCZERO, RAPH, MDX

### DIFF
--- a/src/Gulden/auto_checkpoints_activation.cpp
+++ b/src/Gulden/auto_checkpoints_activation.cpp
@@ -47,9 +47,9 @@ namespace Checkpoints
                 // { "KOIN", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
                 // { "PIRATE", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
                 { "THC", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
-                // { "BCZERO", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
-                // { "RAPH", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
-                // { "MDX", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
+                { "BCZERO", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
+                { "RAPH", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
+                { "MDX", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
 
                 // test chains:
                 { "DOC", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},

--- a/src/Gulden/auto_checkpoints_activation.cpp
+++ b/src/Gulden/auto_checkpoints_activation.cpp
@@ -47,9 +47,9 @@ namespace Checkpoints
                 // { "KOIN", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
                 // { "PIRATE", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
                 { "THC", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
-                { "BCZERO", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
-                { "RAPH", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
-                { "MDX", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
+                { "BCZERO", { nBczeroRaphMdxSyncCheckpointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
+                { "RAPH", { nBczeroRaphMdxSyncCheckpointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
+                { "MDX", { nBczeroRaphMdxSyncCheckpointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},
 
                 // test chains:
                 { "DOC", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }},

--- a/src/komodo_hardfork.cpp
+++ b/src/komodo_hardfork.cpp
@@ -32,7 +32,7 @@ const int32_t nSyncChkPointHeight = nSunsettingHeight;
 // asset chain auto checkpoint activation time
 const uint32_t nSyncChkPointTimestamp = nSunsettingTimestamp;
 
-const uint32_t nBczeroRaphMdxSyncCheckpointTimestamp = 1771167600; // Feb 15, 2026 15:00 UTC
+const uint32_t nBczeroRaphMdxSyncCheckpointTimestamp = 1769526000; // 27 Jan 2026 15:00 UTC
 
 // Era array of pubkeys. Add extra seasons to bottom as requried, after adding appropriate info above. 
 const char *notaries_elected[NUM_KMD_SEASONS][NUM_KMD_NOTARIES][2] =

--- a/src/komodo_hardfork.cpp
+++ b/src/komodo_hardfork.cpp
@@ -32,6 +32,8 @@ const int32_t nSyncChkPointHeight = nSunsettingHeight;
 // asset chain auto checkpoint activation time
 const uint32_t nSyncChkPointTimestamp = nSunsettingTimestamp;
 
+const uint32_t nBczeroRaphMdxSyncCheckpointTimestamp = 1771167600; // Feb 15, 2026 15:00 UTC
+
 // Era array of pubkeys. Add extra seasons to bottom as requried, after adding appropriate info above. 
 const char *notaries_elected[NUM_KMD_SEASONS][NUM_KMD_NOTARIES][2] =
 {

--- a/src/komodo_hardfork.h
+++ b/src/komodo_hardfork.h
@@ -56,3 +56,5 @@ extern const int32_t nSyncChkPointHeight;
 
 extern const int32_t nSunsettingHeight;
 extern const uint32_t nSunsettingTimestamp;
+
+extern const uint32_t nBczeroRaphMdxSyncCheckpointTimestamp;


### PR DESCRIPTION
Just enable auto checkpoints for more asset chains: BCZERO, RAPH, MDX.
The activation timestamp is 27 Jan 2026 15:00 UTC.