### PR TITLE
security: fix remote null-deref / use-after-free in block & script validation

### DIFF
--- a/src/cc/heir.cpp
+++ b/src/cc/heir.cpp
@@ -281,9 +281,14 @@ uint8_t _DecodeHeirOpRet(vscript_t vopret, CPubKey& ownerPubkey, CPubKey& heirPu
     uint8_t heirFuncId = 0;
     
     fundingTxidInOpret = zeroid; //to init
-    
+
+    if (vopret.empty()) {
+        if (!noLogging) std::cerr << "_DecodeHeirOpRet() empty opret" << std::endl;
+        return (uint8_t)0;
+    }
+
     evalCodeInOpret = vopret.begin()[0];
-    
+
     if (vopret.size() > 1 && evalCodeInOpret == EVAL_HEIR) {
         // NOTE: it unmarshals for all F, A and C
         uint8_t heirFuncId = 0;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -438,7 +438,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), 1));
     strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with Bloom filters (default: %u)"), 1));
-    strUsage += HelpMessageOpt("-nspv_msg", strprintf(_("Enable NSPV messages processing (default: %u)"), DEFAULT_NSPV_PROCESSING));
+    strUsage += HelpMessageOpt("-nspv_msg", strprintf(_("Enable NSPV messages processing (NOT SUPPORTED: this mode is disabled, the node will refuse to start) (default: %u)"), DEFAULT_NSPV_PROCESSING));
     if (showDebug)
         strUsage += HelpMessageOpt("-enforcenodebloom", strprintf("Enforce minimum protocol version to limit use of Bloom filters (default: %u)", 0));
     strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u or testnet: %u)"), 7770, 17770));
@@ -1195,6 +1195,14 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (nFD - MIN_CORE_FILEDESCRIPTORS < nMaxConnections)
         nMaxConnections = nFD - MIN_CORE_FILEDESCRIPTORS;
     fprintf(stderr,"nMaxConnections %d\n",nMaxConnections);
+    // NSPV message processing is disabled: the getnSPV/nSPV handlers
+    // (komodo_nSPVreq/komodo_nSPVresp) do hand-rolled, insufficiently bounds-checked
+    // binary parsing of attacker-controlled P2P payloads, which is remotely
+    // memory-unsafe (stack buffer overflow / out-of-bounds reads). Refuse to start
+    // with it enabled rather than expose that surface.
+    if (GetBoolArg("-nspv_msg", DEFAULT_NSPV_PROCESSING)) {
+        return InitError(_("NSPV messages processing (-nspv_msg) is not supported: it has been disabled because its P2P message parsing is not memory-safe."));
+    }
     // if using block pruning, then disable txindex
     // also disable the wallet (for now, until SPV support is implemented in wallet)
     if (GetArg("-prune", 0)) {

--- a/src/komodo_bitcoind.cpp
+++ b/src/komodo_bitcoind.cpp
@@ -633,6 +633,10 @@ int32_t komodo_hasOpRet(int32_t height, uint32_t timestamp)
 
 bool komodo_checkopret(CBlock *pblock, CScript &merkleroot)
 {
+    // guard against a malformed block: the merkleroot opret lives in the last
+    // vout of the last tx, but vtx/vout may be empty before per-tx validation
+    if ( pblock->vtx.empty() || pblock->vtx.back().vout.empty() )
+        return false;
     merkleroot = pblock->vtx.back().vout.back().scriptPubKey;
     return(merkleroot.IsOpReturn() && merkleroot == komodo_makeopret(pblock, false));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3427,7 +3427,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         }
     }
     */
-    CCheckQueueControl<CScriptCheck> control(fExpensiveChecks && nScriptCheckThreads ? &scriptcheckqueue : NULL);
 
     int64_t nTimeStart = GetTimeMicros();
     CAmount nFees = 0;
@@ -3473,6 +3472,13 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     CAmount burnedAmountDelta = 0;
     std::vector<PrecomputedTransactionData> txdata;
     txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
+    // SECURITY (CVE-2024-52911 class, use-after-free): `control` MUST be declared
+    // AFTER `txdata`. Local objects are destroyed in reverse order of construction,
+    // so this guarantees `control` is destroyed FIRST — its destructor (Wait) joins
+    // all background script-check threads while `txdata` (the PrecomputedTransactionData
+    // they hold pointers into) is still alive. Reordering these two declarations
+    // reintroduces the use-after-free on any early return. Do NOT move this above txdata.
+    CCheckQueueControl<CScriptCheck> control(fExpensiveChecks && nScriptCheckThreads ? &scriptcheckqueue : NULL);
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         const CTransaction &tx = block.vtx[i];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5114,7 +5114,7 @@ bool CheckBlock(int32_t *futureblockp, int32_t height, CBlockIndex *pindex, cons
         CValidationState& state, libzcash::ProofVerifier& verifier, bool fCheckPOW, 
         bool fCheckMerkleRoot)
 {
-    uint8_t pubkey33[33]; 
+    uint8_t pubkey33[33] = {0}; // init: komodo_block2pubkey33() only runs under fCheckPOW, but the December-hardfork branch below reads pubkey33 unconditionally
     uint32_t tiptime = (uint32_t)block.nTime;
     // These are checks that are independent of context.
     uint256 hash = block.GetHash();

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -497,8 +497,8 @@ bool CScript::IsCoinImport() const
     vector<unsigned char> data;
     opcodetype opcode;
     if (this->GetOp(pc, opcode, data))
-        if (opcode > OP_0 && opcode <= OP_PUSHDATA4)
-            return data.begin()[0] == EVAL_IMPORTCOIN;
+        if (opcode > OP_0 && opcode <= OP_PUSHDATA4 && !data.empty())
+            return data[0] == EVAL_IMPORTCOIN;
     return false;
 }
 


### PR DESCRIPTION
  ## Changes

  ### 1. Fix remote null-deref and use-after-free in block/script validation
  - **`ConnectBlock` use-after-free (CVE-2024-52911 class):** moved the
    `CCheckQueueControl<CScriptCheck> control` declaration to *after* `txdata`.
    Locals are destroyed in reverse construction order, so `control`'s destructor
    (which `Wait()`s on the background script-check threads) must run *before*
    `txdata` — the `PrecomputedTransactionData` those threads hold pointers into.
    With the old ordering, an early return destroyed `txdata` while worker threads
    could still dereference it. A comment documents the ordering requirement so it
    isn't silently reintroduced.
  - **`CScript::IsCoinImport()` out-of-bounds read:** guard with `!data.empty()`
    and use `data[0]` instead of `data.begin()[0]`, so an empty push doesn't read
    past the buffer.
  - **`_DecodeHeirOpRet()` empty-opret deref:** bail out early on an empty
    `vopret` instead of dereferencing `vopret.begin()[0]`.

  ### 2. Harden `CheckBlock` against uninitialized `pubkey33` and `komodo_checkopret` OOB
  - Zero-initialize `uint8_t pubkey33[33]`: `komodo_block2pubkey33()` only fills it
    under `fCheckPOW`, but the December-hardfork branch reads it unconditionally —
    previously it could read uninitialized stack memory.
  - `komodo_checkopret()`: guard against `pblock->vtx` / `vout` being empty before
    dereferencing `vtx.back().vout.back()`, which can happen before per-tx
    validation on a malformed block.

  ### 3. Refuse to start with `-nspv_msg` 
  - The `getnSPV`/`nSPV` handlers (`komodo_nSPVreq`/`komodo_nSPVresp`) do
    hand-rolled, insufficiently bounds-checked binary parsing of attacker-controlled
    P2P payloads (stack buffer overflow / OOB reads). Rather than ship that attack
    surface, the node now refuses to start with `-nspv_msg` enabled and the help
    text marks the option as unsupported/disabled.
    
    (c) https://github.com/DeckerSU/KomodoOcean/pull/116